### PR TITLE
Implement conversion from one-tuple of value into Row

### DIFF
--- a/src/ast/row.rs
+++ b/src/ast/row.rs
@@ -38,6 +38,16 @@ where
     }
 }
 
+impl<'a, A> From<(A,)> for Row<'a>
+where
+    A: Into<DatabaseValue<'a>>,
+{
+    #[inline]
+    fn from((val,): (A,)) -> Self {
+        Row::new().push(val)
+    }
+}
+
 impl<'a, A, B> From<(A, B)> for Row<'a>
 where
     A: Into<DatabaseValue<'a>>,


### PR DESCRIPTION
For consistency. Currently you can write:

```rust
Insert::multi_into((SCHEMA_NAME, "Test"), vec!["id", "name"])
        .values(("a", "b"))
        .values(("c", "d"));
```

But you can't insert a single value per row that way.

This commit makes the following code possible:

```rust
Insert::multi_into((SCHEMA_NAME, "Test"), vec!["id"])
        .values(("a",))
        .values(("c",));
```

Alternatively (or additionally), we could implement a conversion from `Into<DatabaseValue>` to `Row`, but it feels a bit too magic to me.