### PR TITLE
Store SQLite file paths as String

### DIFF
--- a/src/ast/grouping.rs
+++ b/src/ast/grouping.rs
@@ -1,6 +1,6 @@
 use crate::ast::{Column, DatabaseValue};
 
-pub type GroupByDefinition<'a> = (DatabaseValue<'a>);
+pub type GroupByDefinition<'a> = DatabaseValue<'a>;
 
 /// A list of definitions for the `GROUP BY` statement
 #[derive(Debug, Default, PartialEq, Clone)]

--- a/src/pool/sqlite.rs
+++ b/src/pool/sqlite.rs
@@ -3,16 +3,15 @@ use crate::{
     error::Error,
 };
 use futures::future;
-use std::path::PathBuf;
 use tokio_resource_pool::{CheckOut, Manage, RealDependencies, Status};
 
 pub struct SqliteManager {
-    file_path: PathBuf,
+    file_path: String,
     db_name: String,
 }
 
 impl SqliteManager {
-    pub fn new(file_path: PathBuf, db_name: &str) -> Self {
+    pub fn new(file_path: String, db_name: &str) -> Self {
         Self {
             file_path,
             db_name: db_name.to_owned(),
@@ -29,7 +28,7 @@ impl Manage for SqliteManager {
     type RecycleFuture = DBIO<'static, Option<Self::Resource>>;
 
     fn create(&self) -> Self::CreateFuture {
-        match Sqlite::new(self.file_path.clone()) {
+        match Sqlite::new(&self.file_path) {
             Ok(mut conn) => match conn.attach_database(&self.db_name) {
                 Ok(_) => DBIO::new(future::ok(conn)),
                 Err(e) => DBIO::new(future::err(e)),


### PR DESCRIPTION
This is changed from PathBuf because we need the file paths to be valid
UTF-8 to pass them in as parameters to `ATTACH ? AS ?` queries. This
would result in repeated fallible conversions that are removed by this
commit.