### PR TITLE
Clarify the meaning of schema_name on ConnectionInfo

### DIFF
--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -188,12 +188,8 @@ impl PostgresUrl {
     }
 
     /// The database schema, defaults to `public`.
-    pub fn schema(&self) -> String {
-        self.url
-            .query_pairs()
-            .find(|(key, _value)| key == "schema")
-            .map(|(_key, value)| value.into_owned())
-            .unwrap_or_else(|| DEFAULT_SCHEMA.to_string())
+    pub fn schema(&self) -> &str {
+        &self.query_params.schema
     }
 
     fn default_connection_limit() -> usize {

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -11,6 +11,8 @@ use futures::future;
 use rusqlite::NO_PARAMS;
 use std::{collections::HashSet, convert::TryFrom, path::Path, sync::Mutex};
 
+const DEFAULT_SCHEMA_NAME: &str = "quaint";
+
 /// A connector interface for the SQLite database
 pub struct Sqlite {
     pub(crate) client: Mutex<rusqlite::Connection>,
@@ -24,7 +26,7 @@ pub struct SqliteParams {
     /// This is not a `PathBuf` because we need to `ATTACH` the database to the path, and this can
     /// only be done with UTF-8 paths.
     pub file_path: String,
-    pub db_name: Option<String>,
+    pub db_name: String,
 }
 
 type ConnectionParams = (Vec<(String, String)>, Vec<(String, String)>);
@@ -87,7 +89,7 @@ impl TryFrom<&str> for SqliteParams {
             Ok(Self {
                 connection_limit: u32::try_from(connection_limit).unwrap(),
                 file_path: path_str.to_owned(),
-                db_name,
+                db_name: db_name.unwrap_or_else(|| DEFAULT_SCHEMA_NAME.to_owned()),
             })
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), quaint::error::Error> {
-//!     let quaint = Quaint::new("sqlite:///tmp/test.db")?;
+//!     let quaint = Quaint::new("file:///tmp/example.db")?;
 //!     let conn = quaint.check_out().await?;
 //!     let result = conn.select(Select::default().value(1)).await?;
 //!

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -69,7 +69,7 @@ pub enum QuaintManager {
     #[cfg(feature = "sqlite")]
     Sqlite {
         file_path: String,
-        db_name: Option<String>,
+        db_name: String,
     },
 }
 
@@ -88,12 +88,11 @@ impl Manage for QuaintManager {
                 use crate::connector::Sqlite;
 
                 match Sqlite::new(&file_path) {
-                    Ok(mut conn) => match db_name {
-                        Some(ref name) => match conn.attach_database(name) {
+                    Ok(mut conn) => {
+                         match conn.attach_database(db_name) {
                             Ok(_) => DBIO::new(future::ok(Box::new(conn) as Self::Resource)),
                             Err(e) => DBIO::new(future::err(e)),
-                        },
-                        None => DBIO::new(future::ok(Box::new(conn) as Self::Resource)),
+                        }
                     },
                     Err(e) => DBIO::new(future::err(e)),
                 }


### PR DESCRIPTION
- Make the db_name (schema name) on SQLite required, defaulting to "quaint".
- Make ConnectionInfo::schema return a non-nullable string
- Remove duplicated schema name logic in postgres connector