### PR TITLE
Errors should hold the original code and message

### DIFF
--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -1,5 +1,5 @@
 use crate::ast::*;
-use crate::error::Error;
+use crate::error::{Error, ErrorKind};
 use rust_decimal::{
     prelude::{FromPrimitive, ToPrimitive},
     Decimal,
@@ -376,7 +376,9 @@ impl<'a> TryFrom<ParameterizedValue<'a>> for i64 {
     type Error = Error;
 
     fn try_from(value: ParameterizedValue<'a>) -> Result<i64, Self::Error> {
-        value.as_i64().ok_or(Error::ConversionError("Not an i64"))
+        value.as_i64().ok_or_else(|| {
+            Error::builder(ErrorKind::ConversionError("Not an i64")).build()
+        })
     }
 }
 
@@ -384,7 +386,9 @@ impl<'a> TryFrom<ParameterizedValue<'a>> for Decimal {
     type Error = Error;
 
     fn try_from(value: ParameterizedValue<'a>) -> Result<Decimal, Self::Error> {
-        value.as_decimal().ok_or(Error::ConversionError("Not a decimal"))
+        value.as_decimal().ok_or_else(|| {
+            Error::builder(ErrorKind::ConversionError("Not a decimal")).build()
+        })
     }
 }
 
@@ -395,7 +399,9 @@ impl<'a> TryFrom<ParameterizedValue<'a>> for f64 {
         value
             .as_decimal()
             .and_then(|d| d.to_f64())
-            .ok_or(Error::ConversionError("Not a f64"))
+            .ok_or_else(|| {
+                Error::builder(ErrorKind::ConversionError("Not a f64")).build()
+            })
     }
 }
 
@@ -403,7 +409,9 @@ impl<'a> TryFrom<ParameterizedValue<'a>> for String {
     type Error = Error;
 
     fn try_from(value: ParameterizedValue<'a>) -> Result<String, Self::Error> {
-        value.into_string().ok_or(Error::ConversionError("Not a string"))
+        value.into_string().ok_or_else(|| {
+            Error::builder(ErrorKind::ConversionError("Not a string")).build()
+        })
     }
 }
 
@@ -411,7 +419,9 @@ impl<'a> TryFrom<ParameterizedValue<'a>> for bool {
     type Error = Error;
 
     fn try_from(value: ParameterizedValue<'a>) -> Result<bool, Self::Error> {
-        value.as_bool().ok_or(Error::ConversionError("Not a bool"))
+        value.as_bool().ok_or_else(|| {
+            Error::builder(ErrorKind::ConversionError("Not a bool")).build()
+        })
     }
 }
 
@@ -420,7 +430,9 @@ impl<'a> TryFrom<ParameterizedValue<'a>> for DateTime<Utc> {
     type Error = Error;
 
     fn try_from(value: ParameterizedValue<'a>) -> Result<DateTime<Utc>, Self::Error> {
-        value.as_datetime().ok_or(Error::ConversionError("Not a datetime"))
+        value.as_datetime().ok_or_else(|| {
+            Error::builder(ErrorKind::ConversionError("Not a datetime")).build()
+        })
     }
 }
 

--- a/src/connector/connection_info.rs
+++ b/src/connector/connection_info.rs
@@ -1,4 +1,4 @@
-use crate::error::Error;
+use crate::error::{Error, ErrorKind};
 use std::{borrow::Cow, fmt};
 use url::Url;
 
@@ -53,7 +53,12 @@ impl ConnectionInfo {
         let url = url_result?;
 
         let sql_family = SqlFamily::from_scheme(url.scheme()).ok_or_else(|| {
-            Error::DatabaseUrlIsInvalid(format!("{} is not a supported database URL scheme.", url.scheme()))
+            let kind = ErrorKind::DatabaseUrlIsInvalid(format!(
+                "{} is not a supported database URL scheme.",
+                url.scheme())
+            );
+
+            Error::builder(kind).build()
         })?;
 
         match sql_family {

--- a/src/connector/mysql/error.rs
+++ b/src/connector/mysql/error.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, DatabaseConstraint};
+use crate::error::{DatabaseConstraint, Error, ErrorKind};
 use mysql_async as my;
 use std::io::ErrorKind as IoErrorKind;
 
@@ -8,56 +8,86 @@ impl From<my::error::Error> for Error {
 
         match e {
             my::error::Error::Io(io_error) => match io_error.kind() {
-                IoErrorKind::ConnectionRefused => Error::ConnectionError(io_error.into()),
-                _ => Error::QueryError(io_error.into()),
+                IoErrorKind::ConnectionRefused => Error::builder(ErrorKind::ConnectionError(io_error.into())).build(),
+                _ => Error::builder(ErrorKind::QueryError(io_error.into())).build(),
             },
-            my::error::Error::Driver(e) => Error::QueryError(e.into()),
+            my::error::Error::Driver(e) => Error::builder(ErrorKind::QueryError(e.into())).build(),
             my::error::Error::Server(ServerError { ref message, code, .. }) if code == 1062 => {
                 let splitted: Vec<&str> = message.split_whitespace().collect();
                 let splitted: Vec<&str> = splitted.last().map(|s| s.split('\'').collect()).unwrap();
 
                 let index = splitted[1].split(".").last().unwrap().to_string();
 
-                Error::UniqueConstraintViolation {
+                let mut builder = Error::builder(ErrorKind::UniqueConstraintViolation {
                     constraint: DatabaseConstraint::Index(index),
-                }
+                });
+
+                builder.set_original_code(format!("{}", code));
+                builder.set_original_message(message);
+
+                builder.build()
             }
             my::error::Error::Server(ServerError { ref message, code, .. }) if code == 1263 => {
                 let splitted: Vec<&str> = message.split_whitespace().collect();
                 let splitted: Vec<&str> = splitted.last().map(|s| s.split('\'').collect()).unwrap();
 
-                Error::NullConstraintViolation {
+                let mut builder = Error::builder(ErrorKind::NullConstraintViolation {
                     constraint: DatabaseConstraint::Index(splitted[1].to_string()),
-                }
+                });
+
+                builder.set_original_code(format!("{}", code));
+                builder.set_original_message(message);
+
+                builder.build()
             }
             my::error::Error::Server(ServerError { ref message, code, .. }) if code == 1364 => {
                 let splitted: Vec<&str> = message.split_whitespace().collect();
                 let splitted: Vec<&str> = splitted.get(1).map(|s| s.split('\'').collect()).unwrap();
 
-                Error::NullConstraintViolation {
+                let mut builder = Error::builder(ErrorKind::NullConstraintViolation {
                     constraint: DatabaseConstraint::Fields(vec![splitted[1].to_string()]),
-                }
+                });
+
+                builder.set_original_code(format!("{}", code));
+                builder.set_original_message(message);
+
+                builder.build()
             }
             my::error::Error::Server(ServerError { ref message, code, .. }) if code == 1049 => {
                 let splitted: Vec<&str> = message.split_whitespace().collect();
                 let splitted: Vec<&str> = splitted.last().map(|s| s.split('\'').collect()).unwrap();
                 let db_name: String = splitted[1].into();
 
-                Error::DatabaseDoesNotExist { db_name }
+                let mut builder = Error::builder(ErrorKind::DatabaseDoesNotExist { db_name });
+
+                builder.set_original_code(format!("{}", code));
+                builder.set_original_message(message);
+
+                builder.build()
             }
             my::error::Error::Server(ServerError { ref message, code, .. }) if code == 1007 => {
                 let splitted: Vec<&str> = message.split_whitespace().collect();
                 let splitted: Vec<&str> = splitted[3].split('\'').collect();
                 let db_name: String = splitted[1].into();
 
-                Error::DatabaseAlreadyExists { db_name }
+                let mut builder = Error::builder(ErrorKind::DatabaseAlreadyExists { db_name });
+
+                builder.set_original_code(format!("{}", code));
+                builder.set_original_message(message);
+
+                builder.build()
             }
             my::error::Error::Server(ServerError { ref message, code, .. }) if code == 1044 => {
                 let splitted: Vec<&str> = message.split_whitespace().collect();
                 let splitted: Vec<&str> = splitted.last().map(|s| s.split('\'').collect()).unwrap();
                 let db_name: String = splitted[1].into();
 
-                Error::DatabaseAccessDenied { db_name }
+                let mut builder = Error::builder(ErrorKind::DatabaseAccessDenied { db_name });
+
+                builder.set_original_code(format!("{}", code));
+                builder.set_original_message(message);
+
+                builder.build()
             }
             my::error::Error::Server(ServerError { ref message, code, .. }) if code == 1045 => {
                 let splitted: Vec<&str> = message.split_whitespace().collect();
@@ -65,9 +95,34 @@ impl From<my::error::Error> for Error {
                 let splitted: Vec<&str> = splitted[0].split('\'').collect();
                 let user: String = splitted[1].into();
 
-                Error::AuthenticationFailed { user }
+                let mut builder = Error::builder(ErrorKind::AuthenticationFailed { user });
+
+                builder.set_original_code(format!("{}", code));
+                builder.set_original_message(message);
+
+                builder.build()
             }
-            e => Error::QueryError(e.into()),
+            my::error::Error::Server(ServerError {
+                ref message,
+                code,
+                ref state,
+            }) => {
+                let kind = ErrorKind::QueryError(
+                    my::error::Error::Server(ServerError {
+                        message: message.clone(),
+                        code,
+                        state: state.clone(),
+                    })
+                    .into(),
+                );
+
+                let mut builder = Error::builder(kind);
+                builder.set_original_code(format!("{}", code));
+                builder.set_original_message(message);
+
+                builder.build()
+            }
+            e => Error::builder(ErrorKind::QueryError(e.into())).build(),
         }
     }
 }

--- a/src/connector/result_set.rs
+++ b/src/connector/result_set.rs
@@ -4,7 +4,7 @@ mod result_row;
 pub use index::*;
 pub use result_row::*;
 
-use crate::ast::ParameterizedValue;
+use crate::{ast::ParameterizedValue, error::*};
 use std::sync::Arc;
 
 #[cfg(feature = "json-1")]
@@ -74,7 +74,7 @@ impl ResultSet {
     pub fn into_single(self) -> crate::Result<ResultRow> {
         match self.into_iter().next() {
             Some(row) => Ok(row),
-            None => Err(crate::error::Error::NotFound),
+            None => Err(Error::builder(ErrorKind::NotFound).build()),
         }
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -3,6 +3,7 @@
 use crate::{
     ast::ParameterizedValue,
     connector::{ResultRow, ResultSet},
+    error::{Error, ErrorKind},
 };
 use serde::{de::Error as SerdeError, de::*};
 
@@ -55,7 +56,9 @@ pub fn from_rows<T: DeserializeOwned>(result_set: ResultSet) -> crate::Result<Ve
 pub fn from_row<T: DeserializeOwned>(row: ResultRow) -> crate::Result<T> {
     let deserializer = RowDeserializer(row);
 
-    T::deserialize(deserializer).map_err(crate::error::Error::FromRowError)
+    T::deserialize(deserializer).map_err(|e| {
+        Error::builder(ErrorKind::FromRowError(e)).build()
+    })
 }
 
 type DeserializeError = serde::de::value::Error;


### PR DESCRIPTION
This is a breaking change. For whatever code that relied on matching the `Error` will now have to match the `ErrorKind` that's returned from `kind()`.