### PR TITLE
Execute/execute raw, the return

### DIFF
--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -93,7 +93,7 @@ impl GetRow for PostgresRow {
                         ParameterizedValue::Json(val)
                     }
                     None => ParameterizedValue::Null,
-                }
+                },
                 #[cfg(feature = "array")]
                 PostgresType::INT2_ARRAY => match row.try_get(i)? {
                     Some(val) => {

--- a/src/connector/queryable.rs
+++ b/src/connector/queryable.rs
@@ -18,36 +18,39 @@ pub trait Queryable
 where
     Self: Sync,
 {
-    /// Executes the given query and returns the result set.
+    /// Execute the given query.
     fn query<'a>(&'a self, q: Query<'a>) -> DBIO<'a, ResultSet>;
 
-    /// Executes a query given as SQL, interpolating the given parameters and
-    /// returning a set of results.
+    /// Execute a query given as SQL, interpolating the given parameters.
     fn query_raw<'a>(&'a self, sql: &'a str, params: &'a [ParameterizedValue<'a>]) -> DBIO<'a, ResultSet>;
 
-    /// Runs a command in the database, for queries that can't be run using
+    /// Execute the given query, returning the number of affected rows.
+    fn execute<'a>(&'a self, q: Query<'a>) -> DBIO<'a, u64>;
+
+    /// Execute a query given as SQL, interpolating the given parameters and
+    /// returning the number of affected rows.
+    fn execute_raw<'a>(&'a self, sql: &'a str, params: &'a [ParameterizedValue<'a>]) -> DBIO<'a, u64>;
+
+    /// Run a command in the database, for queries that can't be run using
     /// prepared statements.
     fn raw_cmd<'a>(&'a self, cmd: &'a str) -> DBIO<'a, ()>;
 
-    // For selecting data returning the results.
+    /// Execute a `SELECT` query.
     fn select<'a>(&'a self, q: Select<'a>) -> DBIO<'a, ResultSet> {
         self.query(q.into())
     }
 
-    /// For inserting data. Returns the ID of the last inserted row.
+    /// Execute an `INSERT` query.
     fn insert<'a>(&'a self, q: Insert<'a>) -> DBIO<'a, ResultSet> {
         self.query(q.into())
     }
 
-    /// For updating data.
-    fn update<'a>(&'a self, q: Update<'a>) -> DBIO<'a, ()> {
-        DBIO::new(async move {
-            self.query(q.into()).await?;
-            Ok(())
-        })
+    /// Execute an `UPDATE` query, returning the number of affected rows.
+    fn update<'a>(&'a self, q: Update<'a>) -> DBIO<'a, u64> {
+        self.execute(q.into())
     }
 
-    /// For deleting data.
+    /// Execute a `DELETE` query, returning the number of affected rows.
     fn delete<'a>(&'a self, q: Delete<'a>) -> DBIO<'a, ()> {
         DBIO::new(async move {
             self.query(q.into()).await?;

--- a/src/connector/result_set/result_row.rs
+++ b/src/connector/result_set/result_row.rs
@@ -1,4 +1,7 @@
-use crate::ast::ParameterizedValue;
+use crate::{
+    ast::ParameterizedValue,
+    error::{Error, ErrorKind},
+};
 use std::sync::Arc;
 
 /// An owned version of a `Row` in a `ResultSet`. See
@@ -65,6 +68,13 @@ impl ResultRow {
         ResultRowRef {
             columns: Arc::clone(&self.columns),
             values: &self.values,
+        }
+    }
+
+    pub fn into_single(self) -> crate::Result<ParameterizedValue<'static>> {
+        match self.into_iter().next() {
+            Some(val) => Ok(val),
+            None => Err(Error::builder(ErrorKind::NotFound).build()),
         }
     }
 }

--- a/src/connector/sqlite/error.rs
+++ b/src/connector/sqlite/error.rs
@@ -97,15 +97,9 @@ impl From<rusqlite::Error> for Error {
                 }
 
                 builder.build()
-            },
+            }
 
-            rusqlite::Error::SqliteFailure(
-                ffi::Error {
-                    extended_code,
-                    ..
-                },
-                ref description,
-            ) => {
+            rusqlite::Error::SqliteFailure(ffi::Error { extended_code, .. }, ref description) => {
                 let description = description.as_ref().map(|d| d.to_string());
                 let mut builder = Error::builder(ErrorKind::QueryError(e.into()));
                 builder.set_original_code(format!("{}", extended_code));
@@ -115,7 +109,7 @@ impl From<rusqlite::Error> for Error {
                 }
 
                 builder.build()
-            },
+            }
             e => Error::builder(ErrorKind::QueryError(e.into())).build(),
         }
     }

--- a/src/connector/transaction.rs
+++ b/src/connector/transaction.rs
@@ -36,8 +36,16 @@ impl<'a> Queryable for Transaction<'a> {
         self.inner.query(q)
     }
 
+    fn execute<'b>(&'b self, q: Query<'b>) -> DBIO<'b, u64> {
+        self.inner.execute(q)
+    }
+
     fn query_raw<'b>(&'b self, sql: &'b str, params: &'b [ParameterizedValue]) -> DBIO<'b, ResultSet> {
         self.inner.query_raw(sql, params)
+    }
+
+    fn execute_raw<'b>(&'b self, sql: &'b str, params: &'b [ParameterizedValue<'b>]) -> DBIO<'b, u64> {
+        self.inner.execute_raw(sql, params)
     }
 
     fn raw_cmd<'b>(&'b self, cmd: &'b str) -> DBIO<'b, ()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 //! Error module
-use std::{fmt, io};
+use std::{fmt, io, num};
 use thiserror::Error;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -148,6 +148,21 @@ pub enum ErrorKind {
     #[cfg(feature = "serde-support")]
     #[error("Deserializing a ResultRow {:?}", _0)]
     FromRowError(serde::de::value::Error),
+}
+
+impl From<Error> for ErrorKind {
+    fn from(e: Error) -> Self {
+        e.kind
+    }
+}
+
+impl From<num::TryFromIntError> for Error {
+    fn from(_: num::TryFromIntError) -> Self {
+        Self::builder(ErrorKind::ConversionError(
+            "Couldn't convert an integer (possible overflow).",
+        ))
+        .build()
+    }
 }
 
 #[cfg(feature = "pooled")]

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -10,7 +10,7 @@ use crate::{
     connector::{self, Queryable, TransactionCapable, DBIO},
     error::Error,
 };
-use mobc::{Manager, Connection as MobcPooled};
+use mobc::{Connection as MobcPooled, Manager};
 
 /// A connection from the pool. Implements
 /// [Queryable](connector/trait.Queryable.html).
@@ -25,8 +25,16 @@ impl Queryable for PooledConnection {
         self.inner.query(q)
     }
 
+    fn execute<'a>(&'a self, q: ast::Query<'a>) -> DBIO<'a, u64> {
+        self.inner.execute(q)
+    }
+
     fn query_raw<'a>(&'a self, sql: &'a str, params: &'a [ast::ParameterizedValue]) -> DBIO<'a, connector::ResultSet> {
         self.inner.query_raw(sql, params)
+    }
+
+    fn execute_raw<'a>(&'a self, sql: &'a str, params: &'a [ast::ParameterizedValue]) -> DBIO<'a, u64> {
+        self.inner.execute_raw(sql, params)
     }
 
     fn raw_cmd<'a>(&'a self, cmd: &'a str) -> DBIO<'a, ()> {


### PR DESCRIPTION
For queries where we need the number of rows affected, we really need
the execute variants of query functions.