### PR TITLE
Introduce VALUES construct

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -15,6 +15,7 @@ mod function;
 mod grouping;
 mod insert;
 mod join;
+mod ops;
 mod ordering;
 mod over;
 mod query;
@@ -24,7 +25,6 @@ mod table;
 mod union;
 mod update;
 mod values;
-mod ops;
 
 pub use column::Column;
 pub use compare::{Comparable, Compare};
@@ -36,6 +36,7 @@ pub use function::*;
 pub use grouping::*;
 pub use insert::*;
 pub use join::{Join, JoinData, Joinable};
+pub use ops::*;
 pub use ordering::{IntoOrderDefinition, Order, OrderDefinition, Orderable, Ordering};
 pub use over::*;
 pub use query::Query;
@@ -44,8 +45,7 @@ pub use select::Select;
 pub use table::*;
 pub use union::Union;
 pub use update::*;
-pub use ops::*;
 
 #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgresql"))]
 pub(crate) use values::Params;
-pub use values::{asterisk, DatabaseValue, ParameterizedValue};
+pub use values::{asterisk, DatabaseValue, ParameterizedValue, Values};

--- a/src/ast/select.rs
+++ b/src/ast/select.rs
@@ -49,7 +49,7 @@ impl<'a> Select<'a> {
     /// assert_eq!("SELECT `crm`.`users`.* FROM `crm`.`users`", sql);
     /// ```
     ///
-    /// It is also possible to use a nested `SELECT`.
+    /// Selecting from a nested `SELECT`.
     ///
     /// ```rust
     /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
@@ -59,6 +59,28 @@ impl<'a> Select<'a> {
     ///
     /// assert_eq!("SELECT `num`.* FROM (SELECT ?) AS `num`", sql);
     /// assert_eq!(vec![ParameterizedValue::from(1)], params);
+    /// ```
+    ///
+    /// Selecting from a set of values.
+    ///
+    /// ```rust
+    /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
+    /// # use quaint::values;
+    /// let expected_sql = "SELECT `vals`.* FROM (VALUES (?,?),(?,?)) AS `vals`";
+    /// let values = Table::from(values!((1, 2), (3, 4))).alias("vals");
+    /// let query = Select::from_table(values);
+    /// let (sql, params) = Sqlite::build(query);
+    ///
+    /// assert_eq!(expected_sql, sql);
+    /// assert_eq!(
+    ///     vec![
+    ///         ParameterizedValue::Integer(1),
+    ///         ParameterizedValue::Integer(2),
+    ///         ParameterizedValue::Integer(3),
+    ///         ParameterizedValue::Integer(4),
+    ///     ],
+    ///     params
+    /// );
     /// ```
     #[inline]
     pub fn from_table<T>(table: T) -> Self

--- a/src/ast/table.rs
+++ b/src/ast/table.rs
@@ -1,4 +1,4 @@
-use crate::ast::{DatabaseValue, Select};
+use crate::ast::{DatabaseValue, Row, Select, Values};
 use std::borrow::Cow;
 
 /// An object that can be aliased.
@@ -14,6 +14,7 @@ pub trait Aliasable<'a> {
 pub enum TableType<'a> {
     Table(Cow<'a, str>),
     Query(Select<'a>),
+    Values(Values<'a>),
 }
 
 /// A table definition
@@ -65,6 +66,24 @@ impl<'a> From<String> for Table<'a> {
     fn from(s: String) -> Self {
         Table {
             typ: TableType::Table(s.into()),
+            alias: None,
+            database: None,
+        }
+    }
+}
+
+impl<'a> From<Vec<Row<'a>>> for Table<'a> {
+    #[inline]
+    fn from(values: Vec<Row<'a>>) -> Self {
+        Table::from(Values::from(values.into_iter()))
+    }
+}
+
+impl<'a> From<Values<'a>> for Table<'a> {
+    #[inline]
+    fn from(values: Values<'a>) -> Self {
+        Self {
+            typ: TableType::Values(values),
             alias: None,
             database: None,
         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,7 +1,7 @@
 //! A "prelude" for users of the `quaint` crate.
-pub use crate::{val, col};
 pub use crate::ast::*;
 #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgresql"))]
 pub use crate::connector::{
     ConnectionInfo, Queryable, ResultRow, ResultSet, SqlFamily, Transaction, TransactionCapable, DBIO,
 };
+pub use crate::{col, val, values};


### PR DESCRIPTION
Works in SQLite, PostgreSQL and MySQL 8 and later.

What is missing is that in MySQL 8 you can define the columns from the values selection, which I couldn't get to work in other databases:

```sql
MySQL [prisma]> select * from (values row(1, 2), row(3, 4)) as a (foo, bar);
+-----+-----+
| foo | bar |
+-----+-----+
|   1 |   2 |
|   3 |   4 |
+-----+-----+
2 rows in set (0.001 sec)
```