### PR TITLE
Flatten the recursion in ConditionTree

### DIFF
--- a/src/ast/conditions.rs
+++ b/src/ast/conditions.rs
@@ -4,9 +4,9 @@ use crate::ast::*;
 #[derive(Debug, PartialEq, Clone)]
 pub enum ConditionTree<'a> {
     /// `(left_expression AND right_expression)`
-    And(Box<Expression<'a>>, Box<Expression<'a>>),
+    And(Vec<Expression<'a>>),
     /// `(left_expression OR right_expression)`
-    Or(Box<Expression<'a>>, Box<Expression<'a>>),
+    Or(Vec<Expression<'a>>),
     /// `(NOT expression)`
     Not(Box<Expression<'a>>),
     /// A single expression leaf
@@ -20,22 +20,40 @@ pub enum ConditionTree<'a> {
 impl<'a> ConditionTree<'a> {
     /// An `AND` statement, is true when both sides are true.
     #[inline]
-    pub fn and<E, J>(left: E, right: J) -> ConditionTree<'a>
+    pub fn and<E>(mut self, other: E) -> ConditionTree<'a>
     where
         E: Into<Expression<'a>>,
-        J: Into<Expression<'a>>,
     {
-        ConditionTree::And(Box::new(left.into()), Box::new(right.into()))
+        match self {
+            Self::And(ref mut conditions) => {
+                conditions.push(other.into());
+                self
+            }
+            Self::Or(_) => Self::And(vec![Expression::from(self), other.into()]),
+            Self::Not(_) => Self::And(vec![Expression::from(self), other.into()]),
+            Self::Single(expr) => Self::And(vec![*expr, other.into()]),
+            Self::NoCondition => self,
+            Self::NegativeCondition => Self::And(vec![Expression::from(self), other.into()]),
+        }
     }
 
     /// An `OR` statement, is true when one side is true.
     #[inline]
-    pub fn or<E, J>(left: E, right: J) -> ConditionTree<'a>
+    pub fn or<E>(mut self, other: E) -> ConditionTree<'a>
     where
         E: Into<Expression<'a>>,
-        J: Into<Expression<'a>>,
     {
-        ConditionTree::Or(Box::new(left.into()), Box::new(right.into()))
+        match self {
+            Self::Or(ref mut conditions) => {
+                conditions.push(other.into());
+                self
+            }
+            Self::And(_) => Self::Or(vec![Expression::from(self), other.into()]),
+            Self::Not(_) => Self::Or(vec![Expression::from(self), other.into()]),
+            Self::Single(expr) => Self::Or(vec![*expr, other.into()]),
+            Self::NoCondition => self,
+            Self::NegativeCondition => Self::Or(vec![Expression::from(self), other.into()]),
+        }
     }
 
     /// A `NOT` statement, is true when the expression is false.

--- a/src/ast/conjuctive.rs
+++ b/src/ast/conjuctive.rs
@@ -8,7 +8,10 @@ pub trait Conjuctive<'a> {
     /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
     /// assert_eq!(
     ///     "foo".equals("bar").and("wtf".less_than(3)),
-    ///     ConditionTree::and("foo".equals("bar"), "wtf".less_than(3))
+    ///     ConditionTree::And(vec![
+    ///         Expression::from("foo".equals("bar")),
+    ///         Expression::from("wtf".less_than(3))
+    ///     ])
     /// )
     /// ```
     fn and<E>(self, other: E) -> ConditionTree<'a>
@@ -21,7 +24,10 @@ pub trait Conjuctive<'a> {
     /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
     /// assert_eq!(
     ///     "foo".equals("bar").or("wtf".less_than(3)),
-    ///     ConditionTree::or("foo".equals("bar"), "wtf".less_than(3))
+    ///     ConditionTree::Or(vec![
+    ///         Expression::from("foo".equals("bar")),
+    ///         Expression::from("wtf".less_than(3))
+    ///     ])
     /// )
     /// ```
     fn or<E>(self, other: E) -> ConditionTree<'a>
@@ -49,7 +55,7 @@ where
     where
         E: Into<Expression<'a>>,
     {
-        ConditionTree::and(self.into(), other.into())
+        ConditionTree::And(vec![self.into(), other.into()])
     }
 
     #[inline]
@@ -57,7 +63,7 @@ where
     where
         E: Into<Expression<'a>>,
     {
-        ConditionTree::or(self.into(), other.into())
+        ConditionTree::Or(vec![self.into(), other.into()])
     }
 
     #[inline]

--- a/src/connector/connection_info.rs
+++ b/src/connector/connection_info.rs
@@ -53,10 +53,8 @@ impl ConnectionInfo {
         let url = url_result?;
 
         let sql_family = SqlFamily::from_scheme(url.scheme()).ok_or_else(|| {
-            let kind = ErrorKind::DatabaseUrlIsInvalid(format!(
-                "{} is not a supported database URL scheme.",
-                url.scheme())
-            );
+            let kind =
+                ErrorKind::DatabaseUrlIsInvalid(format!("{} is not a supported database URL scheme.", url.scheme()));
 
             Error::builder(kind).build()
         })?;

--- a/src/connector/result_set.rs
+++ b/src/connector/result_set.rs
@@ -20,11 +20,7 @@ pub struct ResultSet {
 
 impl ResultSet {
     /// Creates a new instance, bound to the given column names and result rows.
-    pub fn new(
-        names: Vec<String>,
-        rows: Vec<Vec<ParameterizedValue<'static>>>,
-    ) -> Self
-    {
+    pub fn new(names: Vec<String>, rows: Vec<Vec<ParameterizedValue<'static>>>) -> Self {
         Self {
             columns: Arc::new(names),
             rows,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@
 //! let (sql_str, params) = Sqlite::build(query);
 //!
 //! assert_eq!(
-//!     "SELECT `naukio`.* FROM `naukio` WHERE ((`word` = ? AND `age` < ?) AND `paw` = ?)",
+//!     "SELECT `naukio`.* FROM `naukio` WHERE (`word` = ? AND `age` < ? AND `paw` = ?)",
 //!     sql_str,
 //! );
 //!

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -5,8 +5,8 @@ pub use manager::{PooledConnection, QuaintManager};
 
 use crate::connector::{ConnectionInfo, SqlFamily};
 use mobc::Pool;
-use url::Url;
 use std::sync::Arc;
+use url::Url;
 
 #[cfg(feature = "sqlite")]
 use std::convert::TryFrom;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -408,15 +408,31 @@ pub trait Visitor<'a> {
     /// A walk through the query conditions
     fn visit_conditions(&mut self, tree: ConditionTree<'a>) -> fmt::Result {
         match tree {
-            ConditionTree::And(left, right) => self.surround_with("(", ")", |ref mut s| {
-                s.visit_expression(*left)?;
-                s.write(" AND ")?;
-                s.visit_expression(*right)
+            ConditionTree::And(expressions) => self.surround_with("(", ")", |ref mut s| {
+                let len = expressions.len();
+
+                for (i, expr) in expressions.into_iter().enumerate() {
+                    s.visit_expression(expr)?;
+
+                    if i < (len - 1) {
+                        s.write(" AND ")?;
+                    }
+                }
+
+                Ok(())
             }),
-            ConditionTree::Or(left, right) => self.surround_with("(", ")", |ref mut s| {
-                s.visit_expression(*left)?;
-                s.write(" OR ")?;
-                s.visit_expression(*right)
+            ConditionTree::Or(expressions) => self.surround_with("(", ")", |ref mut s| {
+                let len = expressions.len();
+
+                for (i, expr) in expressions.into_iter().enumerate() {
+                    s.visit_expression(expr)?;
+
+                    if i < (len - 1) {
+                        s.write(" OR ")?;
+                    }
+                }
+
+                Ok(())
             }),
             ConditionTree::Not(expression) => self.surround_with("(", ")", |ref mut s| {
                 s.write("NOT ")?;

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -307,7 +307,7 @@ mod tests {
 
     #[test]
     fn test_select_and() {
-        let expected_sql = "SELECT `naukio`.* FROM `naukio` WHERE ((`word` = ? AND `age` < ?) AND `paw` = ?)";
+        let expected_sql = "SELECT `naukio`.* FROM `naukio` WHERE (`word` = ? AND `age` < ? AND `paw` = ?)";
 
         let expected_params = vec![
             ParameterizedValue::Text(Cow::from("meow")),
@@ -399,11 +399,7 @@ mod tests {
             ParameterizedValue::Text(Cow::from("warm")),
         ];
 
-        let conditions = ConditionTree::not(ConditionTree::and(
-            ConditionTree::or("word".equals("meow"), "age".less_than(10)),
-            "paw".equals("warm"),
-        ));
-
+        let conditions = ConditionTree::not("word".equals("meow").or("age".less_than(10)).and("paw".equals("warm")));
         let query = Select::from_table("naukio").so_that(conditions);
 
         let (sql, params) = Sqlite::build(query);


### PR DESCRIPTION
We used to recurse for every element in an AND or OR tree, causing a
stack overflow with quite a small trees. This change flattens the trees
a bit to prevent recursing too much.

An example:

```rust
"foo".equals("bar").and("omg".less_than(1)).or("wtf".equals("omg"))
```

The old code would generate the following condition tree:

```rust
ConditionTree::Or(
    ConditionTree::And(
        "foo".equals("bar"),
        "omg".less_than(1),
    ),
    "wtf".equals("omg"),
)
```

And the generated SQL would be something like:

```sql
(("foo" = 'bar' AND "omg" < 1) OR "wtf" = 'omg')
```

The new version does it a bit differently:

```rust
ConditionTree::Or(vec![
    ConditionTree::And("foo".equals("bar", "omg".less_than(1))),
    "wtf".equals("omg"),
])
```

Which will generate the following SQL:

```sql
(("foo" = 'bar' AND "omg" < 1) OR "wtf" = 'omg')
```

So here we recurse only when switching from `AND` to `OR` and back. Or
have a sigular `NOT` where we must cut the scope with parentheses for
correct results.