### PR TITLE
Yeet debug-stub dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ serde-support = ["serde", "chrono/serde"]
 url = "2.1"
 metrics = "0.12"
 percent-encoding = "2"
-debug_stub_derive = "0.3"
 lazy_static = "1.4"
 num_cpus = "1.12"
 rust_decimal = "=1.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,10 +113,6 @@ extern crate log;
 #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgresql"))]
 extern crate metrics;
 
-#[macro_use]
-#[cfg(all(feature = "array", feature = "postgresql"))]
-extern crate debug_stub_derive;
-
 pub mod ast;
 #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgresql"))]
 pub mod connector;


### PR DESCRIPTION
The crate hasn't been updated in three years, and it pulls in old versions of syn and quote.