### PR TITLE
Improve messages when cert/identity files are not found

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -138,7 +138,7 @@ pub enum ErrorKind {
     #[error("The provided arguments are not supported")]
     InvalidConnectionArguments,
 
-    #[error("Error in an I/O operation")]
+    #[error("Error in an I/O operation: {0}")]
     IoError(io::Error),
 
     #[error("Connect timed out ({0})")]


### PR DESCRIPTION
On postgres.

From investigating this issue: https://github.com/prisma/prisma2/issues/1651