### PR TITLE
Add support for money columns on postgres

### DIFF
--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -561,6 +561,7 @@ mod tests {
                 numeric_float4 float4,
                 numeric_float4_arr float4[],
                 numeric_float8 float8,
+                numeric_decimal decimal(12,8),
                 numeric_money money,
                 time_timetz timetz,
                 time_time time,
@@ -590,6 +591,11 @@ mod tests {
             .value("numeric_float4_arr", ParameterizedValue::Array(vec![3.14.into()]))
             .value("numeric_float8", 3.14912932)
             .value(
+                "numeric_decimal",
+                ParameterizedValue::Real("0.00006927".parse().unwrap()),
+            )
+            .value("numeric_money", 3.551)
+            .value(
                 "time_date",
                 ParameterizedValue::DateTime("2020-03-02T08:00:00Z".parse().unwrap()),
             )
@@ -605,8 +611,7 @@ mod tests {
             .value(
                 "time_timestamptz",
                 ParameterizedValue::DateTime("2020-03-02T08:00:00Z".parse().unwrap()),
-            )
-            .value("numeric_money", 3.55);
+            );
         let select = ast::Select::from_table("types").value(ast::asterisk());
 
         connection.query(insert.into()).await.unwrap();
@@ -630,6 +635,7 @@ mod tests {
             ParameterizedValue::Real("3.14".parse().unwrap()),
             ParameterizedValue::Array(vec![3.14.into()]),
             ParameterizedValue::Real("3.14912932".parse().unwrap()),
+            ParameterizedValue::Real("0.00006927".parse().unwrap()),
             ParameterizedValue::Real("3.55".parse().unwrap()),
             ParameterizedValue::DateTime("1970-01-01T08:00:00Z".parse().unwrap()),
             ParameterizedValue::DateTime("1970-01-01T08:00:00Z".parse().unwrap()),

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -417,10 +417,12 @@ impl<'a> ToSql for ParameterizedValue<'a> {
             }
             (ParameterizedValue::Real(decimal), &PostgresType::MONEY) => {
                 let mut i64_bytes: [u8; 8] = [0; 8];
-                i64_bytes.copy_from_slice(&decimal.round_dp(2).serialize()[4..12]);
-                let i = i64::from_le_bytes(i64_bytes) * 10i64.pow(decimal.scale());
+                let decimal = (decimal * Decimal::new(100, 0)).round();
+                i64_bytes.copy_from_slice(&decimal.serialize()[4..12]);
+                let i = i64::from_le_bytes(i64_bytes);
                 i.to_sql(ty, out)
             }
+            (ParameterizedValue::Real(decimal), &PostgresType::NUMERIC) => decimal.to_sql(ty, out),
             (ParameterizedValue::Real(float), _) => float.to_sql(ty, out),
             #[cfg(feature = "uuid-0_8")]
             (ParameterizedValue::Text(string), &PostgresType::UUID) => {


### PR DESCRIPTION
We assume the default precision of 2 decimals here. If the server is
configured differently, the values will be wrong.