### PR TITLE
Optimize certain IN selections

### DIFF
--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -174,7 +174,7 @@ impl<'a> SingleRowInsert<'a> {
         V: Into<DatabaseValue<'a>>,
     {
         self.columns.push(key.into());
-        self.values = self.values.push(val.into());
+        self.values.push(val.into());
 
         self
     }

--- a/src/ast/row.rs
+++ b/src/ast/row.rs
@@ -17,16 +17,23 @@ impl<'a> Row<'a> {
         Row { values: Vec::with_capacity(capacity) }
     }
 
-    pub fn push<T>(mut self, value: T) -> Self
+    pub fn pop(&mut self) -> Option<DatabaseValue<'a>> {
+        self.values.pop()
+    }
+
+    pub fn push<T>(&mut self, value: T)
     where
         T: Into<DatabaseValue<'a>>,
     {
         self.values.push(value.into());
-        self
     }
 
     pub fn is_empty(&self) -> bool {
         self.values.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.values.len()
     }
 }
 
@@ -34,9 +41,14 @@ impl<'a, T> From<Vec<T>> for Row<'a>
 where
     T: Into<DatabaseValue<'a>>,
 {
-    #[inline]
     fn from(vector: Vec<T>) -> Row<'a> {
-        vector.into_iter().fold(Row::new(), |row, v| row.push(v.into()))
+        let mut row = Row::with_capacity(vector.len());
+
+        for v in vector.into_iter() {
+            row.push(v.into());
+        }
+
+        row
     }
 }
 
@@ -44,9 +56,10 @@ impl<'a, A> From<(A,)> for Row<'a>
 where
     A: Into<DatabaseValue<'a>>,
 {
-    #[inline]
     fn from((val,): (A,)) -> Self {
-        Row::with_capacity(1).push(val)
+        let mut row = Row::with_capacity(1);
+        row.push(val);
+        row
     }
 }
 
@@ -55,9 +68,13 @@ where
     A: Into<DatabaseValue<'a>>,
     B: Into<DatabaseValue<'a>>,
 {
-    #[inline]
     fn from(vals: (A, B)) -> Self {
-        Row::with_capacity(2).push(vals.0).push(vals.1)
+        let mut row = Row::with_capacity(2);
+
+        row.push(vals.0);
+        row.push(vals.1);
+
+        row
     }
 }
 
@@ -69,7 +86,13 @@ where
 {
     #[inline]
     fn from(vals: (A, B, C)) -> Self {
-        Row::with_capacity(3).push(vals.0).push(vals.1).push(vals.2)
+        let mut row = Row::with_capacity(3);
+
+        row.push(vals.0);
+        row.push(vals.1);
+        row.push(vals.2);
+
+        row
     }
 }
 
@@ -82,7 +105,14 @@ where
 {
     #[inline]
     fn from(vals: (A, B, C, D)) -> Self {
-        Row::with_capacity(4).push(vals.0).push(vals.1).push(vals.2).push(vals.3)
+        let mut row = Row::with_capacity(4);
+
+        row.push(vals.0);
+        row.push(vals.1);
+        row.push(vals.2);
+        row.push(vals.3);
+
+        row
     }
 }
 
@@ -96,12 +126,15 @@ where
 {
     #[inline]
     fn from(vals: (A, B, C, D, E)) -> Self {
-        Row::with_capacity(5)
-            .push(vals.0)
-            .push(vals.1)
-            .push(vals.2)
-            .push(vals.3)
-            .push(vals.4)
+        let mut row = Row::with_capacity(5);
+
+        row.push(vals.0);
+        row.push(vals.1);
+        row.push(vals.2);
+        row.push(vals.3);
+        row.push(vals.4);
+
+        row
     }
 }
 

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -817,13 +817,19 @@ impl<'a> Values<'a> {
         Self::default()
     }
 
+    /// Create a new in-memory set of values with an allocated capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            rows: Vec::with_capacity(capacity)
+        }
+    }
+
     /// Add value to the temporary table.
-    pub fn push<T>(mut self, row: T) -> Self
+    pub fn push<T>(&mut self, row: T)
     where
         T: Into<Row<'a>>,
     {
         self.rows.push(row.into());
-        self
     }
 
     /// The number of rows in the in-memory table.
@@ -834,6 +840,26 @@ impl<'a> Values<'a> {
     /// True if has no rows.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+
+    pub fn row_len(&self) -> usize {
+        match self.rows.split_first() {
+            Some((row, _)) => row.len(),
+            None => 0,
+        }
+    }
+
+    pub fn flatten_row(self) -> Option<Row<'a>> {
+        let mut result = Row::with_capacity(self.len());
+
+        for mut row in self.rows.into_iter() {
+            match row.pop() {
+                Some(value) => result.push(value),
+                None => return None
+            }
+        }
+
+        Some(result)
     }
 }
 

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -408,8 +408,11 @@ VALUES (1, 'Joe', 27, 20000.00 );
 
         // 1-tuple
         {
-            let cols = Row::new().push(Column::from("age"));
-            let vals = Row::new().push(35);
+            let mut cols = Row::new();
+            cols.push(Column::from("age"));
+
+            let mut vals = Row::new();
+            vals.push(35);
 
             let select = Select::from_table("tuples").so_that(cols.in_selection(vals));
             let rows = connection.select(select).await.unwrap();

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -574,8 +574,11 @@ mod tests {
 
         // 1-tuple
         {
-            let cols = Row::new().push(Column::from("age"));
-            let vals = Row::new().push(35);
+            let mut cols = Row::new();
+            cols.push(Column::from("age"));
+
+            let mut vals = Row::new();
+            vals.push(35);
 
             let select = Select::from_table("tuples").so_that(cols.in_selection(vals));
             let rows = connection.select(select).await.unwrap();

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -274,8 +274,11 @@ mod tests {
 
         // 1-tuple
         {
-            let cols = Row::new().push(Column::from("age"));
-            let vals = Row::new().push(35);
+            let mut cols = Row::new();
+            cols.push(Column::from("age"));
+
+            let mut vals = Row::new();
+            vals.push(35);
 
             let select = Select::from_table("tuples").so_that(cols.in_selection(vals));
             let rows = connection.select(select).await.unwrap();

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -214,6 +214,38 @@ mod tests {
     }
 
     #[test]
+    fn test_in_values_singular() {
+        let mut cols = Row::new();
+        cols.push(Column::from("id1"));
+
+        let mut vals = Values::new();
+
+        {
+            let mut row1 = Row::new();
+            row1.push(1);
+
+            let mut row2 = Row::new();
+            row2.push(2);
+
+            vals.push(row1);
+            vals.push(row2);
+        }
+
+        let query = Select::from_table("test").so_that(cols.in_selection(vals));
+        let (sql, params) = Sqlite::build(query);
+        let expected_sql = "SELECT `test`.* FROM `test` WHERE `id1` IN (?,?)";
+
+        assert_eq!(expected_sql, sql);
+        assert_eq!(
+            vec![
+                ParameterizedValue::Integer(1),
+                ParameterizedValue::Integer(2),
+            ],
+            params
+        )
+    }
+
+    #[test]
     fn test_select_order_by() {
         let expected_sql = "SELECT `musti`.* FROM `musti` ORDER BY `foo`, `baz` ASC, `bar` DESC";
         let query = Select::from_table("musti")


### PR DESCRIPTION
If we select with a row.in_selection(values), we want to optimize cases
where row and values both contain only one item.

So that

```sql
(foo) IN ((1), (2))
```

becomes

```sql
foo IN (1, 2)
```