### PR TITLE
Clean function, ordering and grouping interfaces.

### DIFF
--- a/src/ast/function/aggregate_to_string.rs
+++ b/src/ast/function/aggregate_to_string.rs
@@ -1,3 +1,4 @@
+use super::Function;
 use crate::ast::DatabaseValue;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -18,11 +19,13 @@ pub struct AggregateToString<'a> {
 /// assert_eq!("SELECT GROUP_CONCAT(`firstName`) FROM `users` GROUP BY `firstName`", sql);
 /// ```
 #[inline]
-pub fn aggregate_to_string<'a, T>(expr: T) -> AggregateToString<'a>
+pub fn aggregate_to_string<'a, T>(expr: T) -> Function<'a>
 where
     T: Into<DatabaseValue<'a>>,
 {
-    AggregateToString {
+    let fun = AggregateToString {
         value: Box::new(expr.into()),
-    }
+    };
+
+    fun.into()
 }

--- a/src/ast/function/average.rs
+++ b/src/ast/function/average.rs
@@ -1,3 +1,4 @@
+use super::Function;
 use crate::ast::Column;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -14,9 +15,10 @@ pub struct Average<'a> {
 /// assert_eq!("SELECT AVG(`age`) FROM `users`", sql);
 /// ```
 #[inline]
-pub fn avg<'a, C>(col: C) -> Average<'a>
+pub fn avg<'a, C>(col: C) -> Function<'a>
 where
     C: Into<Column<'a>>,
 {
-    Average { column: col.into() }
+    let fun = Average { column: col.into() };
+    fun.into()
 }

--- a/src/ast/function/count.rs
+++ b/src/ast/function/count.rs
@@ -1,3 +1,4 @@
+use super::Function;
 use crate::ast::DatabaseValue;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -15,11 +16,13 @@ pub struct Count<'a> {
 /// assert_eq!("SELECT COUNT(*) FROM `users`", sql);
 /// ```
 #[inline]
-pub fn count<'a, T>(expr: T) -> Count<'a>
+pub fn count<'a, T>(expr: T) -> Function<'a>
 where
     T: Into<DatabaseValue<'a>>,
 {
-    Count {
+    let fun = Count {
         exprs: vec![expr.into()],
-    }
+    };
+
+    fun.into()
 }

--- a/src/ast/function/sum.rs
+++ b/src/ast/function/sum.rs
@@ -1,3 +1,4 @@
+use super::Function;
 use crate::ast::Column;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -9,14 +10,16 @@ pub struct Sum<'a> {
 ///
 /// ```rust
 /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
-/// let query = Select::from_table("users").value(sum("age"));
+/// let query = Select::from_table("users").value(sum("age").alias("sum"));
 /// let (sql, _) = Sqlite::build(query);
-/// assert_eq!("SELECT SUM(`age`) FROM `users`", sql);
+/// assert_eq!("SELECT SUM(`age`) AS `sum` FROM `users`", sql);
 /// ```
 #[inline]
-pub fn sum<'a, C>(col: C) -> Sum<'a>
+pub fn sum<'a, C>(col: C) -> Function<'a>
 where
     C: Into<Column<'a>>,
 {
-    Sum { column: col.into() }
+    let fun = Sum { column: col.into() };
+
+    fun.into()
 }

--- a/src/ast/grouping.rs
+++ b/src/ast/grouping.rs
@@ -46,6 +46,14 @@ impl<'a> IntoGroupByDefinition<'a> for &'a str {
     }
 }
 
+impl<'a> IntoGroupByDefinition<'a> for (&'a str, &'a str) {
+    #[inline]
+    fn into_group_by_definition(self) -> GroupByDefinition<'a> {
+        let column: Column = self.into();
+        column.into()
+    }
+}
+
 impl<'a> IntoGroupByDefinition<'a> for Column<'a> {
     #[inline]
     fn into_group_by_definition(self) -> GroupByDefinition<'a> {

--- a/src/ast/ordering.rs
+++ b/src/ast/ordering.rs
@@ -95,3 +95,11 @@ impl<'a> Orderable<'a> for &'a str {
         column.order(order)
     }
 }
+
+impl<'a> Orderable<'a> for (&'a str, &'a str) {
+    #[inline]
+    fn order(self, order: Option<Order>) -> OrderDefinition<'a> {
+        let column: Column<'a> = self.into();
+        column.order(order)
+    }
+}


### PR DESCRIPTION
This allows us to:

```rust
Select::from_table("foo").value(sum("bar").alias("sum_of_bar"))
```

... and

```rust
Select::from_table("foo").group_by(("foo", "version"))
```

... and

```rust
Select::from_table("foo").order_by(("foo", "version").ascend())
```

No need to explicitly `Column::from` anymore