### PR TITLE
Avoid float precision drift on mysql

### DIFF
--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -364,7 +364,7 @@ CREATE TABLE `user`(
 
     const CREATE_USER: &str = r#"
 INSERT INTO `user` (id, name, age, salary)
-VALUES (1, 'Joe', 27, 20000.00 );
+VALUES (1, 'Joe', 27, 20000.006 );
 "#;
 
     const DROP_TABLE: &str = "DROP TABLE IF EXISTS `user`;";
@@ -387,7 +387,7 @@ VALUES (1, 'Joe', 27, 20000.00 );
         assert_eq!(row["name"].as_str(), Some("Joe"));
         assert!(row["name"].is_text());
         assert_eq!(row["age"].as_i64(), Some(27));
-        assert_eq!(row["salary"].as_f64(), Some(20000.0));
+        assert_eq!(row["salary"].as_f64(), Some(20000.01));
     }
 
     #[tokio::test]

--- a/src/connector/mysql/conversion.rs
+++ b/src/connector/mysql/conversion.rs
@@ -31,7 +31,14 @@ impl TakeRow for my::Row {
                 my::Value::Int(i) => ParameterizedValue::Integer(i),
                 // TOOD: This is unsafe
                 my::Value::UInt(i) => ParameterizedValue::Integer(i as i64),
-                my::Value::Float(f) => ParameterizedValue::from(f),
+                my::Value::Float(f) => {
+                    let single_precision = f as f32;
+                    if f == single_precision as f64 {
+                        ParameterizedValue::from(single_precision)
+                    } else {
+                        ParameterizedValue::from(f)
+                    }
+                }
                 #[cfg(feature = "chrono-0_4")]
                 my::Value::Date(year, month, day, hour, min, sec, micro) => {
                     let time = NaiveTime::from_hms_micro(hour.into(), min.into(), sec.into(), micro);


### PR DESCRIPTION
This is not the right solution long term, but with this change, any
single-precision float that gets into the database will come out the
same. In very rare cases, we will instead treat an f64 as a f32 and lose
precision.