### PR TITLE
sqlite: open the database as main

### DIFF
--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -111,15 +111,15 @@ impl TryFrom<&str> for Sqlite {
 
     fn try_from(path: &str) -> crate::Result<Self> {
         let params = SqliteParams::try_from(path)?;
+        let file_path = params.file_path;
 
-        let conn = rusqlite::Connection::open_in_memory()?;
+        let conn = rusqlite::Connection::open(file_path.as_str())?;
 
         if let Some(timeout) = params.socket_timeout {
             conn.busy_timeout(timeout)?;
         };
 
         let client = Mutex::new(conn);
-        let file_path = params.file_path;
 
         Ok(Sqlite { client, file_path })
     }


### PR DESCRIPTION
This allows referring to possibly-nonexistent tables with their unqualified names in raw commands, and is more consistent with the behavior of the Postgres and MySQL backends.

In particular, it enables creating tables using the `Queryable` interface.  For instance, one can write `db.cmd_raw("CREATE TABLE my_table (x INTEGER);")` to create a table, instead of `db.cmd_raw("CREATE TABLE db_name.my_table (x INTEGER);")` (where `db_name` is the value of the `db_name` parameter in the database URL).  This is useful because without it, one would have to re-parse the original database URL in order to get the value of `db_name`, and then thread that value through all code that needs to create a table.

For backwards compatibility, the database file is still attached as `db_name` too, so it's mapped as both `main` and `db_name`.