### PR TITLE
Rename "conjuctive" to "conjunctive".

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -8,7 +8,7 @@
 mod column;
 mod compare;
 mod conditions;
-mod conjuctive;
+mod conjunctive;
 mod delete;
 mod expression;
 mod function;
@@ -29,7 +29,7 @@ mod values;
 pub use column::Column;
 pub use compare::{Comparable, Compare};
 pub use conditions::ConditionTree;
-pub use conjuctive::Conjuctive;
+pub use conjunctive::Conjunctive;
 pub use delete::Delete;
 pub use expression::*;
 pub use function::*;

--- a/src/ast/conjunctive.rs
+++ b/src/ast/conjunctive.rs
@@ -1,7 +1,7 @@
 use crate::ast::{ConditionTree, Expression};
 
-/// `AND`, `OR` and `NOT` conjuctive implementations.
-pub trait Conjuctive<'a> {
+/// `AND`, `OR` and `NOT` conjunctive implementations.
+pub trait Conjunctive<'a> {
     /// Builds an `AND` condition having `self` as the left leaf and `other` as the right.
     ///
     /// ```rust
@@ -46,7 +46,7 @@ pub trait Conjuctive<'a> {
     fn not(self) -> ConditionTree<'a>;
 }
 
-impl<'a, T> Conjuctive<'a> for T
+impl<'a, T> Conjunctive<'a> for T
 where
     T: Into<Expression<'a>>,
 {


### PR DESCRIPTION
Since this is an API-breaking change, it might be nice to get it in before 2.0.0.