### PR TITLE
Specialize equality comparisons for JSON in AST visitor

### DIFF
--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -7,6 +7,17 @@ pub struct Expression<'a> {
     pub(crate) alias: Option<Cow<'a, str>>,
 }
 
+impl<'a> Expression<'a> {
+    #[cfg(feature = "json-1")]
+    pub(crate) fn is_json_value(&self) -> bool {
+        match &self.kind {
+            ExpressionKind::Parameterized(Value::Json(_)) => true,
+            ExpressionKind::Value(expr) => expr.is_json_value(),
+            _ => false,
+        }
+    }
+}
+
 /// An expression we can compare and use in database queries.
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExpressionKind<'a> {

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -1016,4 +1016,50 @@ mod tests {
             other => panic!("{:?}", other),
         }
     }
+
+    #[tokio::test]
+    async fn json_filtering_works() {
+        let conn = Quaint::new(&CONN_STR).await.unwrap();
+
+        let create_table = r#"
+            CREATE TABLE "table_with_json" (
+                id SERIAL PRIMARY KEY,
+                obj json
+            )
+        "#;
+
+        let drop_table = r#"DROP TABLE IF EXISTS "table_with_json""#;
+
+        let insert = Insert::single_into("table_with_json").value("obj", serde_json::json!({ "a": "a" }));
+        let second_insert = Insert::single_into("table_with_json").value("obj", serde_json::json!({ "a": "b" }));
+
+        conn.query_raw(drop_table, &[]).await.unwrap();
+        conn.query_raw(create_table, &[]).await.unwrap();
+        conn.query(insert.into()).await.unwrap();
+        conn.query(second_insert.into()).await.unwrap();
+
+        // Equals
+        {
+            let select = Select::from_table("table_with_json")
+                .value(asterisk())
+                .so_that(Column::from("obj").equals(Value::Json(serde_json::json!({ "a": "b" }))));
+
+            let result = conn.query(select.into()).await.unwrap();
+
+            assert_eq!(result.len(), 1);
+            assert_eq!(result.get(0).unwrap().get("id").unwrap(), &Value::Integer(2))
+        }
+
+        // Not equals
+        {
+            let select = Select::from_table("table_with_json")
+                .value(asterisk())
+                .so_that(Column::from("obj").not_equals(Value::Json(serde_json::json!({ "a": "a" }))));
+
+            let result = conn.query(select.into()).await.unwrap();
+
+            assert_eq!(result.len(), 1);
+            assert_eq!(result.get(0).unwrap().get("id").unwrap(), &Value::Integer(2))
+        }
+    }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -454,16 +454,8 @@ pub trait Visitor<'a> {
     /// A comparison expression
     fn visit_compare(&mut self, compare: Compare<'a>) -> fmt::Result {
         match compare {
-            Compare::Equals(left, right) => {
-                self.visit_expression(*left)?;
-                self.write(" = ")?;
-                self.visit_expression(*right)
-            }
-            Compare::NotEquals(left, right) => {
-                self.visit_expression(*left)?;
-                self.write(" <> ")?;
-                self.visit_expression(*right)
-            }
+            Compare::Equals(left, right) => self.visit_condition_equals(*left, *right),
+            Compare::NotEquals(left, right) => self.visit_condition_not_equals(*left, *right),
             Compare::LessThan(left, right) => {
                 self.visit_expression(*left)?;
                 self.write(" < ")?;
@@ -687,6 +679,18 @@ pub trait Visitor<'a> {
                 self.visit_expression(*right)
             }
         }
+    }
+
+    fn visit_condition_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> fmt::Result {
+        self.visit_expression(left)?;
+        self.write(" = ")?;
+        self.visit_expression(right)
+    }
+
+    fn visit_condition_not_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> fmt::Result {
+        self.visit_expression(left)?;
+        self.write(" <> ")?;
+        self.visit_expression(right)
     }
 
     /// A visit in the `ORDER BY` section of the query


### PR DESCRIPTION
I tested this in prisma-engines, and it seems to solve the problem of filtering on JSON values.