### PR TITLE
Pgbouncer mode for PostgreSQL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ single-postgresql = ["postgresql", "json-1", "uuid-0_8", "chrono-0_4", "array"]
 single-mysql = ["mysql", "json-1", "uuid-0_8", "chrono-0_4"]
 single-sqlite = ["sqlite", "json-1", "uuid-0_8", "chrono-0_4"]
 
-pooled = ["mobc", "async-trait"]
+pooled = ["mobc"]
 sqlite = ["rusqlite", "libsqlite3-sys", "tokio/sync"]
 json-1 = ["serde_json", "base64"]
 postgresql = ["rust_decimal/postgres", "native-tls", "tokio-postgres", "postgres-native-tls", "array", "bytes", "tokio", "bit-vec"]
@@ -54,6 +54,7 @@ num_cpus = "1.12"
 rust_decimal = "=1.1.0"
 futures = "0.3"
 thiserror = "1.0"
+async-trait = "0.1"
 
 uuid = { version = "0.8", optional = true }
 chrono = { version = "0.4", optional = true }
@@ -77,7 +78,6 @@ mobc = { version = "0.5.7", optional = true }
 bytes = { version = "0.5", optional = true }
 tokio = { version = "0.2", features = ["rt-threaded", "macros", "sync"], optional = true}
 serde = { version = "1.0", optional = true }
-async-trait = { version = "0.1", optional = true }
 bit-vec = { version = "0.6.1", optional = true }
 
 [dev-dependencies]

--- a/src/connector/queryable.rs
+++ b/src/connector/queryable.rs
@@ -62,6 +62,11 @@ where
     /// corresponds to the `version()` function on PostgreSQL for example. The version string is
     /// returned directly without any form of parsing or normalization.
     fn version<'a>(&'a self) -> DBIO<'a, Option<String>>;
+
+    /// Execute an arbitrary function in the beginning of each transaction.
+    fn server_reset_query<'a>(&'a self, _: &'a Transaction<'a>) -> DBIO<'a, ()> {
+        DBIO::new(futures::future::ready(Ok(())))
+    }
 }
 
 /// A thing that can start a new transaction.
@@ -71,6 +76,6 @@ where
 {
     /// Starts a new transaction
     fn start_transaction(&self) -> DBIO<Transaction> {
-        DBIO::new(async move { Transaction::new(self).await })
+        DBIO::new(async move { Ok(Transaction::new(self).await?) })
     }
 }

--- a/src/connector/transaction.rs
+++ b/src/connector/transaction.rs
@@ -12,8 +12,12 @@ pub struct Transaction<'a> {
 
 impl<'a> Transaction<'a> {
     pub(crate) async fn new(inner: &'a dyn Queryable) -> crate::Result<Transaction<'a>> {
+        let this = Self { inner };
+
         inner.raw_cmd("BEGIN").await?;
-        Ok(Self { inner })
+        inner.server_reset_query(&this).await?;
+
+        Ok(this)
     }
 
     /// Commit the changes to the database and consume the transaction.

--- a/src/connector/transaction.rs
+++ b/src/connector/transaction.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::ast::*;
+use async_trait::async_trait;
 
 /// A representation of an SQL database transaction. If not commited, a
 /// transaction will be rolled back by default when dropped.
@@ -35,28 +36,29 @@ impl<'a> Transaction<'a> {
     }
 }
 
+#[async_trait]
 impl<'a> Queryable for Transaction<'a> {
-    fn query<'b>(&'b self, q: Query<'b>) -> DBIO<'b, ResultSet> {
-        self.inner.query(q)
+    async fn query(&self, q: Query<'_>) -> crate::Result<ResultSet> {
+        self.inner.query(q).await
     }
 
-    fn execute<'b>(&'b self, q: Query<'b>) -> DBIO<'b, u64> {
-        self.inner.execute(q)
+    async fn execute(&self, q: Query<'_>) -> crate::Result<u64> {
+        self.inner.execute(q).await
     }
 
-    fn query_raw<'b>(&'b self, sql: &'b str, params: &'b [Value]) -> DBIO<'b, ResultSet> {
-        self.inner.query_raw(sql, params)
+    async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
+        self.inner.query_raw(sql, params).await
     }
 
-    fn execute_raw<'b>(&'b self, sql: &'b str, params: &'b [Value<'b>]) -> DBIO<'b, u64> {
-        self.inner.execute_raw(sql, params)
+    async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
+        self.inner.execute_raw(sql, params).await
     }
 
-    fn raw_cmd<'b>(&'b self, cmd: &'b str) -> DBIO<'b, ()> {
-        self.inner.raw_cmd(cmd)
+    async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {
+        self.inner.raw_cmd(cmd).await
     }
 
-    fn version<'b>(&'b self) -> DBIO<'b, Option<String>> {
-        self.inner.version()
+    async fn version(&self) -> crate::Result<Option<String>> {
+        self.inner.version().await
     }
 }

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -51,6 +51,12 @@
 //! - `connect_timeout` defined in seconds (default: 5). Connecting to a
 //!   database will return a `ConnectTimeout` error if taking more than the
 //!   defined value.
+//! - `pgbouncer` either `true` or `false`. If set, allows usage with the
+//!   pgBouncer connection pool in transaction mode. Additionally a transaction
+//!   is required for every query for the mode to work. When starting a new
+//!   transaction, a deallocation query `DEALLOCATE ALL` is executed right after
+//!   `BEGIN` to avoid possible collisions with statements created in other
+//!   sessions.
 //!
 //! ## MySQL
 //!

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -1,13 +1,12 @@
-use async_trait::async_trait;
-
 #[cfg(feature = "mysql")]
 use crate::connector::MysqlUrl;
 #[cfg(feature = "postgresql")]
 use crate::connector::PostgresUrl;
+use async_trait::async_trait;
 
 use crate::{
     ast,
-    connector::{self, Queryable, Transaction, TransactionCapable, DBIO},
+    connector::{self, Queryable, Transaction, TransactionCapable},
     error::Error,
 };
 use mobc::{Connection as MobcPooled, Manager};
@@ -20,33 +19,34 @@ pub struct PooledConnection {
 
 impl TransactionCapable for PooledConnection {}
 
+#[async_trait]
 impl Queryable for PooledConnection {
-    fn query<'a>(&'a self, q: ast::Query<'a>) -> DBIO<'a, connector::ResultSet> {
-        self.inner.query(q)
+    async fn query(&self, q: ast::Query<'_>) -> crate::Result<connector::ResultSet> {
+        self.inner.query(q).await
     }
 
-    fn execute<'a>(&'a self, q: ast::Query<'a>) -> DBIO<'a, u64> {
-        self.inner.execute(q)
+    async fn execute(&self, q: ast::Query<'_>) -> crate::Result<u64> {
+        self.inner.execute(q).await
     }
 
-    fn query_raw<'a>(&'a self, sql: &'a str, params: &'a [ast::Value]) -> DBIO<'a, connector::ResultSet> {
-        self.inner.query_raw(sql, params)
+    async fn query_raw(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<connector::ResultSet> {
+        self.inner.query_raw(sql, params).await
     }
 
-    fn execute_raw<'a>(&'a self, sql: &'a str, params: &'a [ast::Value]) -> DBIO<'a, u64> {
-        self.inner.execute_raw(sql, params)
+    async fn execute_raw(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<u64> {
+        self.inner.execute_raw(sql, params).await
     }
 
-    fn raw_cmd<'a>(&'a self, cmd: &'a str) -> DBIO<'a, ()> {
-        self.inner.raw_cmd(cmd)
+    async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {
+        self.inner.raw_cmd(cmd).await
     }
 
-    fn version<'a>(&'a self) -> DBIO<'a, Option<String>> {
-        self.inner.version()
+    async fn version(&self) -> crate::Result<Option<String>> {
+        self.inner.version().await
     }
 
-    fn server_reset_query<'a>(&'a self, tx: &'a Transaction<'a>) -> DBIO<'a, ()> {
-        self.inner.server_reset_query(tx)
+    async fn server_reset_query(&self, tx: &Transaction<'_>) -> crate::Result<()> {
+        self.inner.server_reset_query(tx).await
     }
 }
 

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -7,7 +7,7 @@ use crate::connector::PostgresUrl;
 
 use crate::{
     ast,
-    connector::{self, Queryable, TransactionCapable, DBIO},
+    connector::{self, Queryable, Transaction, TransactionCapable, DBIO},
     error::Error,
 };
 use mobc::{Connection as MobcPooled, Manager};
@@ -43,6 +43,10 @@ impl Queryable for PooledConnection {
 
     fn version<'a>(&'a self) -> DBIO<'a, Option<String>> {
         self.inner.version()
+    }
+
+    fn server_reset_query<'a>(&'a self, tx: &'a Transaction<'a>) -> DBIO<'a, ()> {
+        self.inner.server_reset_query(tx)
     }
 }
 


### PR DESCRIPTION
Introducing a new flag for PostgreSQL: `pgbouncer`.

When `true`, after `BEGIN` of each transaction a query of `DEALLOCATE ALL` is executed to clean existing prepared statements from the session to prevent collisions.

To be able to use Quaint with pgbouncer's transaction mode, every query needs to be inside a transaction and the connection string should have `pgbouncer=true` set.