### PR TITLE
Change phrasing of log message regarding connection count

### DIFF
--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -241,11 +241,18 @@ impl Builder {
 
         #[cfg(not(feature = "tracing-log"))]
         {
-            info!("Starting a {} pool with {} connections.", family, self.connection_limit);
+            info!(
+                "Starting a {} pool with up to {} connections.",
+                family, self.connection_limit
+            );
         }
         #[cfg(feature = "tracing-log")]
         {
-            tracing::info!("Starting a {} pool with {} connections.", family, self.connection_limit);
+            tracing::info!(
+                "Starting a {} pool with up to {} connections.",
+                family,
+                self.connection_limit
+            );
         }
 
         let inner = Pool::builder()


### PR DESCRIPTION
The connections are opened lazily, so the size we give is a maximum size, not a constant size.