### PR TITLE
Use `map` instead of `map_and_drop` on mysql query

### DIFF
--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -293,9 +293,7 @@ impl Queryable for Mysql {
             let last_id = results.last_insert_id();
             let mut result_set = ResultSet::new(columns, Vec::new());
 
-            let (_, rows) = self
-                .timeout(results.map_and_drop(|mut row| row.take_result_row()))
-                .await?;
+            let (_, rows) = self.timeout(results.map(|mut row| row.take_result_row())).await?;
 
             for row in rows.into_iter() {
                 result_set.rows.push(row?);

--- a/src/error.rs
+++ b/src/error.rs
@@ -181,7 +181,14 @@ impl From<mobc::Error<Error>> for Error {
     fn from(e: mobc::Error<Error>) -> Self {
         match e {
             mobc::Error::Inner(e) => e,
-            mobc::Error::Timeout => Error::builder(ErrorKind::Timeout("mobc timeout".into())).build(),
+            mobc::Error::Timeout => {
+                let kind = ErrorKind::Timeout("mobc timeout".into());
+
+                let mut builder = Error::builder(kind);
+                builder.set_original_message("Connection timed out.");
+
+                builder.build()
+            },
             e @ mobc::Error::BadConn => Error::builder(ErrorKind::ConnectionError(Box::new(e))).build(),
         }
     }
@@ -190,7 +197,12 @@ impl From<mobc::Error<Error>> for Error {
 #[cfg(any(feature = "postgresql", feature = "mysql"))]
 impl From<tokio::time::Elapsed> for Error {
     fn from(_: tokio::time::Elapsed) -> Self {
-        Error::builder(ErrorKind::Timeout("tokio timeout".into())).build()
+        let kind = ErrorKind::Timeout("tokio timeout".into());
+
+        let mut builder = Error::builder(kind);
+        builder.set_original_message("Query timed out.");
+
+        builder.build()
     }
 }
 


### PR DESCRIPTION
The `map_and_drop` in `mysql_async` will freeze forever if using it with
stored procedure calls, such as `CALL StoredProcedure()`. For some
reason `map` works.