### PR TITLE
Add DISTINCT to SELECT.

### DIFF
--- a/src/ast/select.rs
+++ b/src/ast/select.rs
@@ -3,6 +3,7 @@ use crate::ast::*;
 /// A builder for a `SELECT` statement.
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Select<'a> {
+    pub(crate) distinct: bool,
     pub(crate) table: Option<Box<Table<'a>>>,
     pub(crate) columns: Vec<Expression<'a>>,
     pub(crate) conditions: Option<ConditionTree<'a>>,
@@ -192,6 +193,23 @@ impl<'a> Select<'a> {
         C: Into<Column<'a>>,
     {
         self.columns = columns.into_iter().map(|c| c.into().into()).collect();
+        self
+    }
+
+    /// Adds `DISTINCT` to the select query.
+    ///
+    /// ```rust
+    /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
+    /// # fn main() -> Result<(), quaint::error::Error> {
+    /// let query = Select::from_table("users").column("foo").column("bar").distinct();
+    /// let (sql, _) = Sqlite::build(query)?;
+    ///
+    /// assert_eq!("SELECT DISTINCT `foo`, `bar` FROM `users`", sql);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn distinct(mut self) -> Self {
+        self.distinct = true;
         self
     }
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -130,6 +130,10 @@ pub trait Visitor<'a> {
     fn visit_select(&mut self, select: Select<'a>) -> Result {
         self.write("SELECT ")?;
 
+        if select.distinct {
+            self.write("DISTINCT ")?;
+        }
+
         if let Some(table) = select.table {
             if select.columns.is_empty() {
                 match table.typ {

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -1198,4 +1198,26 @@ mod tests {
             params
         );
     }
+
+    #[test]
+    fn test_distinct() {
+        let expected_sql = "SELECT DISTINCT [bar] FROM [test]";
+        let query = Select::from_table("test").column(Column::new("bar")).distinct();
+        let (sql, _) = Mssql::build(query).unwrap();
+
+        assert_eq!(expected_sql, sql);
+    }
+
+    #[test]
+    fn test_distinct_with_subquery() {
+        let expected_sql = "SELECT DISTINCT (SELECT @P1 FROM [test2]), [bar] FROM [test]";
+        let query = Select::from_table("test")
+            .value(Select::from_table("test2").value(val!(1)))
+            .column(Column::new("bar"))
+            .distinct();
+
+        let (sql, _) = Mssql::build(query).unwrap();
+
+        assert_eq!(expected_sql, sql);
+    }
 }

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -458,6 +458,28 @@ mod tests {
     }
 
     #[test]
+    fn test_distinct() {
+        let expected_sql = "SELECT DISTINCT `bar` FROM `test`";
+        let query = Select::from_table("test").column(Column::new("bar")).distinct();
+        let (sql, _) = Mysql::build(query).unwrap();
+
+        assert_eq!(expected_sql, sql);
+    }
+
+    #[test]
+    fn test_distinct_with_subquery() {
+        let expected_sql = "SELECT DISTINCT (SELECT ? FROM `test2`), `bar` FROM `test`";
+        let query = Select::from_table("test")
+            .value(Select::from_table("test2").value(val!(1)))
+            .column(Column::new("bar"))
+            .distinct();
+
+        let (sql, _) = Mysql::build(query).unwrap();
+
+        assert_eq!(expected_sql, sql);
+    }
+
+    #[test]
     #[cfg(feature = "json-1")]
     fn test_raw_json() {
         let (sql, params) = Mysql::build(Select::default().value(serde_json::json!({ "foo": "bar" }).raw())).unwrap();

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -347,6 +347,28 @@ mod tests {
         assert_eq!(expected.1, params);
     }
 
+    #[test]
+    fn test_distinct() {
+        let expected_sql = "SELECT DISTINCT \"bar\" FROM \"test\"";
+        let query = Select::from_table("test").column(Column::new("bar")).distinct();
+        let (sql, _) = Postgres::build(query).unwrap();
+
+        assert_eq!(expected_sql, sql);
+    }
+
+    #[test]
+    fn test_distinct_with_subquery() {
+        let expected_sql = "SELECT DISTINCT (SELECT $1 FROM \"test2\"), \"bar\" FROM \"test\"";
+        let query = Select::from_table("test")
+            .value(Select::from_table("test2").value(val!(1)))
+            .column(Column::new("bar"))
+            .distinct();
+
+        let (sql, _) = Postgres::build(query).unwrap();
+
+        assert_eq!(expected_sql, sql);
+    }
+
     #[cfg(feature = "json-1")]
     #[test]
     fn equality_with_a_json_value() {

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -585,6 +585,28 @@ mod tests {
         assert_eq!(expected_sql, sql);
     }
 
+    #[test]
+    fn test_distinct() {
+        let expected_sql = "SELECT DISTINCT `bar` FROM `test`";
+        let query = Select::from_table("test").column(Column::new("bar")).distinct();
+        let (sql, _) = Sqlite::build(query).unwrap();
+
+        assert_eq!(expected_sql, sql);
+    }
+
+    #[test]
+    fn test_distinct_with_subquery() {
+        let expected_sql = "SELECT DISTINCT (SELECT ? FROM `test2`), `bar` FROM `test`";
+        let query = Select::from_table("test")
+            .value(Select::from_table("test2").value(val!(1)))
+            .column(Column::new("bar"))
+            .distinct();
+
+        let (sql, _) = Sqlite::build(query).unwrap();
+
+        assert_eq!(expected_sql, sql);
+    }
+
     #[cfg(feature = "sqlite")]
     fn sqlite_harness() -> ::rusqlite::Connection {
         let conn = ::rusqlite::Connection::open_in_memory().unwrap();


### PR DESCRIPTION
Adds a `.distinct()` function to `Select`, setting a flag on the select and creating a `SELECT DISTINCT ...` query when build.