### PR TITLE
Fix a quite demented param handling in sqlite

### DIFF
--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -320,7 +320,7 @@ impl Quaint {
                 let params = crate::connector::SqliteParams::try_from(s)?;
 
                 let manager = QuaintManager::Sqlite {
-                    file_path: params.file_path,
+                    url: s.to_string(),
                     db_name: params.db_name,
                 };
 

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -65,7 +65,7 @@ pub enum QuaintManager {
     Postgres(PostgresUrl),
 
     #[cfg(feature = "sqlite")]
-    Sqlite { file_path: String, db_name: String },
+    Sqlite { url: String, db_name: String },
 
     #[cfg(feature = "mssql")]
     Mssql(MssqlUrl),
@@ -79,10 +79,10 @@ impl Manager for QuaintManager {
     async fn connect(&self) -> crate::Result<Self::Connection> {
         match self {
             #[cfg(feature = "sqlite")]
-            QuaintManager::Sqlite { file_path, db_name } => {
+            QuaintManager::Sqlite { url, db_name } => {
                 use crate::connector::Sqlite;
 
-                let mut conn = Sqlite::new(&file_path)?;
+                let mut conn = Sqlite::new(&url)?;
                 conn.attach_database(db_name).await?;
 
                 Ok(Box::new(conn) as Self::Connection)


### PR DESCRIPTION
- We don't need supported/unsupported division in params
- And we should store the full url to the pool's manager
- Otherwise parameters get filtered out

Fixes https://github.com/prisma/prisma/issues/2955