### PR TITLE
Test types on pg and my

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ tokio = { version = "0.2", features = ["rt-threaded", "macros"]}
 serde = { version = "1.0", features = ["derive"] }
 indoc = "0.3"
 names = "0.11"
+paste = "1.0"
 
 [dependencies.tiberius]
 git = "https://github.com/prisma/tiberius"

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -569,7 +569,9 @@ value!(val: &'a [u8], Bytes, val.into());
 #[cfg(feature = "chrono-0_4")]
 value!(val: DateTime<Utc>, DateTime, val);
 #[cfg(feature = "chrono-0_4")]
-value!(val: chrono::NaiveTime, Text, val.to_string().into());
+value!(val: chrono::NaiveTime, Time, val);
+#[cfg(feature = "chrono-0_4")]
+value!(val: chrono::NaiveDate, Date, val);
 
 value!(
     val: f64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,8 @@ pub mod serde;
 #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgresql"))]
 pub mod single;
 pub mod visitor;
+#[cfg(test)]
+mod tests;
 
 use once_cell::sync::Lazy;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "mysql")]
+mod mysql;
+#[cfg(feature = "postgresql")]
+mod postgres;
+mod type_test;

--- a/src/tests/mysql.rs
+++ b/src/tests/mysql.rs
@@ -1,0 +1,47 @@
+mod types;
+
+use super::type_test::TypeTest;
+use crate::{connector::Queryable, single::Quaint};
+use names::Generator;
+use once_cell::sync::Lazy;
+use std::env;
+
+static CONN_STR: Lazy<String> = Lazy::new(|| env::var("TEST_MYSQL").expect("TEST_MYSQL env var"));
+
+pub struct MySql<'a> {
+    names: Generator<'a>,
+    conn: Quaint,
+}
+
+#[async_trait::async_trait]
+impl<'a> TypeTest for MySql<'a> {
+    async fn new() -> crate::Result<MySql<'a>> {
+        let names = Generator::default();
+        let conn = Quaint::new(&CONN_STR).await?;
+
+        Ok(Self { names, conn })
+    }
+
+    async fn create_table(&mut self, r#type: &str) -> crate::Result<String> {
+        let table = self.names.next().unwrap().replace('-', "");
+
+        let create_table = format!(
+            r##"
+            CREATE TEMPORARY TABLE `{}` (
+                `id` int(11) NOT NULL AUTO_INCREMENT,
+                `value` {},
+                PRIMARY KEY (`id`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=latin1
+            "##,
+            table, r#type,
+        );
+
+        self.conn.raw_cmd(&create_table).await?;
+
+        Ok(table)
+    }
+
+    fn conn(&self) -> &Quaint {
+        &self.conn
+    }
+}

--- a/src/tests/mysql/types.rs
+++ b/src/tests/mysql/types.rs
@@ -1,0 +1,104 @@
+use super::MySql;
+use crate::tests::type_test::TypeTest;
+use std::str::FromStr;
+
+test_type!(tinyint(
+    MySql,
+    "tinyint(4)",
+    Value::integer(i8::MIN),
+    Value::integer(i8::MAX)
+));
+
+test_type!(year(MySql, "year", Value::integer(1984), Value::integer(2049)));
+
+test_type!(smallint(
+    MySql,
+    "smallint(6)",
+    Value::integer(i16::MIN),
+    Value::integer(i16::MAX)
+));
+
+test_type!(int(
+    MySql,
+    "int(11)",
+    Value::integer(i32::MIN),
+    Value::integer(i32::MAX)
+));
+
+test_type!(bigint(
+    MySql,
+    "bigint(20)",
+    Value::integer(i64::MIN),
+    Value::integer(i64::MAX)
+));
+
+test_type!(decimal(
+    MySql,
+    "decimal(10,2)",
+    Value::real(rust_decimal::Decimal::new(314, 2))
+));
+
+test_type!(float(
+    MySql,
+    "float",
+    Value::real(rust_decimal::Decimal::from_str("1.1234").unwrap())
+));
+
+test_type!(double(
+    MySql,
+    "double",
+    Value::real(rust_decimal::Decimal::from_str("1.12345").unwrap())
+));
+
+test_type!(bit64(MySql, "bit(64)", Value::bytes(vec![0, 0, 0, 0, 0, 6, 107, 58])));
+
+// SQLx can get booleans here!
+test_type!(boolean(MySql, "tinyint(1)", Value::integer(1), Value::integer(0)));
+
+test_type!(char(MySql, "char(255)", Value::text("foobar")));
+test_type!(varchar(MySql, "varchar(255)", Value::text("foobar")));
+test_type!(tinytext(MySql, "tinytext", Value::text("foobar")));
+test_type!(text(MySql, "text", Value::text("foobar")));
+test_type!(mediumtext(MySql, "mediumtext", Value::text("foobar")));
+test_type!(longtext(MySql, "longtext", Value::text("foobar")));
+
+test_type!(binary(MySql, "binary(5)", Value::bytes(vec![1, 2, 3, 0, 0])));
+test_type!(varbinary(MySql, "varbinary(255)", Value::bytes(vec![1, 2, 3])));
+test_type!(tinyblob(MySql, "tinyblob", Value::bytes(vec![1, 2, 3])));
+test_type!(mediumblob(MySql, "mediumblob", Value::bytes(vec![1, 2, 3])));
+test_type!(blob(MySql, "blob", Value::bytes(vec![1, 2, 3])));
+test_type!(longblob(MySql, "longblob", Value::bytes(vec![1, 2, 3])));
+
+test_type!(enum(MySql, "enum('pollicle_dogs','jellicle_cats')", Value::text("jellicle_cats")));
+
+#[cfg(feature = "json-1")]
+test_type!(json(
+    MySql,
+    "json",
+    Value::json(serde_json::json!({"this": "is", "a": "json", "number": 2}))
+));
+
+#[cfg(feature = "chrono-0_4")]
+test_type!(date(MySql, "date", {
+    let dt = chrono::DateTime::parse_from_rfc3339("2020-04-20T00:00:00Z").unwrap();
+    Value::datetime(dt.with_timezone(&chrono::Utc))
+}));
+
+#[cfg(feature = "chrono-0_4")]
+test_type!(time(
+    MySql,
+    "time",
+    Value::time(chrono::NaiveTime::from_hms(16, 20, 00))
+));
+
+#[cfg(feature = "chrono-0_4")]
+test_type!(datetime(MySql, "datetime", {
+    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+    Value::datetime(dt.with_timezone(&chrono::Utc))
+}));
+
+#[cfg(feature = "chrono-0_4")]
+test_type!(timestamp(MySql, "timestamp", {
+    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+    Value::datetime(dt.with_timezone(&chrono::Utc))
+}));

--- a/src/tests/postgres.rs
+++ b/src/tests/postgres.rs
@@ -1,0 +1,46 @@
+mod types;
+
+use super::type_test::TypeTest;
+use crate::{connector::Queryable, single::Quaint};
+use names::Generator;
+use once_cell::sync::Lazy;
+use std::env;
+
+static CONN_STR: Lazy<String> = Lazy::new(|| env::var("TEST_PSQL").expect("TEST_PSQL env var"));
+
+pub struct PostgreSql<'a> {
+    names: Generator<'a>,
+    conn: Quaint,
+}
+
+#[async_trait::async_trait]
+impl<'a> TypeTest for PostgreSql<'a> {
+    async fn new() -> crate::Result<PostgreSql<'a>> {
+        let names = Generator::default();
+        let conn = Quaint::new(&CONN_STR).await?;
+
+        Ok(Self { names, conn })
+    }
+
+    async fn create_table(&mut self, r#type: &str) -> crate::Result<String> {
+        let table = self.names.next().unwrap().replace('-', "");
+
+        let create_table = format!(
+            r##"
+            CREATE TEMPORARY TABLE "{}" (
+                id SERIAL PRIMARY KEY,
+                value {}
+            )
+            "##,
+            table, r#type,
+        );
+
+        self.conn.raw_cmd(&create_table).await?;
+
+        Ok(table)
+    }
+
+    fn conn(&self) -> &Quaint {
+        &self.conn
+    }
+}

--- a/src/tests/postgres/types.rs
+++ b/src/tests/postgres/types.rs
@@ -1,0 +1,325 @@
+use super::PostgreSql;
+use crate::tests::type_test::TypeTest;
+use std::str::FromStr;
+
+test_type!(boolean(
+    PostgreSql,
+    "boolean",
+    Value::boolean(true),
+    Value::boolean(false),
+));
+
+#[cfg(feature = "array")]
+test_type!(boolean_array(
+    PostgreSql,
+    "boolean[]",
+    Value::array(vec![true, false, true]),
+));
+
+test_type!(int2(
+    PostgreSql,
+    "int2",
+    Value::integer(i16::MIN),
+    Value::integer(i16::MAX),
+));
+
+#[cfg(feature = "array")]
+test_type!(int2_array(PostgreSql, "int2[]", Value::array(vec![1, 2, 3]),));
+
+test_type!(int4(
+    PostgreSql,
+    "int4",
+    Value::integer(i32::MIN),
+    Value::integer(i32::MAX),
+));
+
+#[cfg(feature = "array")]
+test_type!(int4_array(PostgreSql, "int4[]", Value::array(vec![1, 2, 3]),));
+
+test_type!(int8(
+    PostgreSql,
+    "int8",
+    Value::integer(i64::MIN),
+    Value::integer(i64::MAX),
+));
+
+#[cfg(feature = "array")]
+test_type!(int8_array(PostgreSql, "int8[]", Value::array(vec![1, 2, 3]),));
+
+test_type!(oid(PostgreSql, "oid", Value::integer(10000)));
+
+#[cfg(feature = "array")]
+test_type!(oid_array(PostgreSql, "oid[]", Value::array(vec![1, 2, 3]),));
+
+test_type!(serial2(
+    PostgreSql,
+    "serial2",
+    Value::integer(i16::MIN),
+    Value::integer(i16::MAX),
+));
+
+test_type!(serial4(
+    PostgreSql,
+    "serial4",
+    Value::integer(i32::MIN),
+    Value::integer(i32::MAX),
+));
+
+test_type!(serial8(
+    PostgreSql,
+    "serial8",
+    Value::integer(i64::MIN),
+    Value::integer(i64::MAX),
+));
+
+test_type!(decimal(
+    PostgreSql,
+    "decimal(10,2)",
+    Value::real(rust_decimal::Decimal::new(314, 2))
+));
+
+#[cfg(feature = "array")]
+test_type!(decimal_array(
+    PostgreSql,
+    "decimal(10,2)[]",
+    Value::array(vec![
+        rust_decimal::Decimal::new(314, 2),
+        rust_decimal::Decimal::new(512, 2)
+    ])
+));
+
+test_type!(float4(
+    PostgreSql,
+    "float4",
+    Value::real(rust_decimal::Decimal::from_str("1.1234").unwrap())
+));
+
+#[cfg(feature = "array")]
+test_type!(float4_array(
+    PostgreSql,
+    "float4[]",
+    Value::array(vec![
+        rust_decimal::Decimal::from_str("1.1234").unwrap(),
+        rust_decimal::Decimal::from_str("4.3210").unwrap(),
+    ])
+));
+
+test_type!(float8(
+    PostgreSql,
+    "float8",
+    Value::real(rust_decimal::Decimal::from_str("1.12345").unwrap())
+));
+
+#[cfg(feature = "array")]
+test_type!(float8_array(
+    PostgreSql,
+    "float8[]",
+    Value::array(vec![
+        rust_decimal::Decimal::from_str("1.1234").unwrap(),
+        rust_decimal::Decimal::from_str("4.3210").unwrap(),
+    ])
+));
+
+test_type!(money(
+    PostgreSql,
+    "money",
+    Value::real(rust_decimal::Decimal::from_str("1.12").unwrap())
+));
+
+#[cfg(feature = "array")]
+test_type!(money_array(
+    PostgreSql,
+    "money[]",
+    Value::array(vec![
+        rust_decimal::Decimal::from_str("1.12").unwrap(),
+        rust_decimal::Decimal::from_str("1.12").unwrap()
+    ])
+));
+
+test_type!(char(PostgreSql, "char(6)", Value::text("foobar")));
+
+#[cfg(feature = "array")]
+test_type!(char_array(
+    PostgreSql,
+    "char(6)[]",
+    Value::array(vec![Value::text("foobar"), Value::text("omgwtf")])
+));
+
+test_type!(varchar(PostgreSql, "varchar(255)", Value::text("foobar")));
+
+#[cfg(feature = "array")]
+test_type!(varchar_array(
+    PostgreSql,
+    "varchar(255)[]",
+    Value::array(vec![Value::text("foobar"), Value::text("omgwtf")])
+));
+
+test_type!(text(PostgreSql, "text", Value::text("foobar")));
+
+#[cfg(feature = "array")]
+test_type!(text_array(
+    PostgreSql,
+    "text[]",
+    Value::array(vec![Value::text("foobar"), Value::text("omgwtf")])
+));
+
+test_type!(bit(PostgreSql, "bit(4)", Value::text("1001")));
+
+#[cfg(feature = "array")]
+test_type!(bit_array(
+    PostgreSql,
+    "bit(4)[]",
+    Value::array(vec![Value::text("1001"), Value::text("0110")])
+));
+
+test_type!(varbit(PostgreSql, "varbit(20)", Value::text("001010101")));
+
+#[cfg(feature = "array")]
+test_type!(varbit_array(
+    PostgreSql,
+    "varbit(20)[]",
+    Value::array(vec![Value::text("001010101"), Value::text("01101111")])
+));
+
+test_type!(inet(PostgreSql, "inet", Value::text("127.0.0.1")));
+
+#[cfg(feature = "array")]
+test_type!(inet_array(
+    PostgreSql,
+    "inet[]",
+    Value::array(vec![Value::text("127.0.0.1"), Value::text("192.168.1.1")])
+));
+
+#[cfg(feature = "json-1")]
+test_type!(json(PostgreSql, "json", Value::json(serde_json::json!({"foo": "bar"}))));
+
+#[cfg(all(feature = "json-1", feature = "array"))]
+test_type!(json_array(
+    PostgreSql,
+    "json[]",
+    Value::array(vec![
+        serde_json::json!({"foo": "bar"}),
+        serde_json::json!({"omg": false})
+    ])
+));
+
+#[cfg(feature = "json-1")]
+test_type!(jsonb(
+    PostgreSql,
+    "jsonb",
+    Value::json(serde_json::json!({"foo": "bar"}))
+));
+
+#[cfg(all(feature = "json-1", feature = "array"))]
+test_type!(jsonb_array(
+    PostgreSql,
+    "jsonb[]",
+    Value::array(vec![
+        serde_json::json!({"foo": "bar"}),
+        serde_json::json!({"omg": false})
+    ])
+));
+
+#[cfg(feature = "uuid-0_8")]
+test_type!(uuid(
+    PostgreSql,
+    "uuid",
+    Value::uuid(uuid::Uuid::from_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8").unwrap())
+));
+
+#[cfg(feature = "chrono-0_4")]
+test_type!(date(
+    PostgreSql,
+    "date",
+    Value::date(chrono::NaiveDate::from_ymd(2020, 4, 20))
+));
+
+#[cfg(all(feature = "chrono-0_4", feature = "array"))]
+test_type!(date_array(
+    PostgreSql,
+    "date[]",
+    Value::array(vec![chrono::NaiveDate::from_ymd(2020, 4, 20)])
+));
+
+#[cfg(feature = "chrono-0_4")]
+test_type!(time(
+    PostgreSql,
+    "time",
+    Value::time(chrono::NaiveTime::from_hms(16, 20, 00))
+));
+
+#[cfg(all(feature = "chrono-0_4", feature = "array"))]
+test_type!(time_array(
+    PostgreSql,
+    "time[]",
+    Value::array(vec![chrono::NaiveTime::from_hms(16, 20, 00)])
+));
+
+#[cfg(feature = "chrono-0_4")]
+test_type!(timestamp(PostgreSql, "timestamp", {
+    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+    Value::datetime(dt.with_timezone(&chrono::Utc))
+}));
+
+#[cfg(all(feature = "chrono-0_4", feature = "array"))]
+test_type!(timestamp_array(PostgreSql, "timestamp[]", {
+    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+    Value::array(vec![dt.with_timezone(&chrono::Utc)])
+}));
+
+#[cfg(feature = "chrono-0_4")]
+test_type!(timestamptz(PostgreSql, "timestamptz", {
+    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+    Value::datetime(dt.with_timezone(&chrono::Utc))
+}));
+
+#[cfg(all(feature = "chrono-0_4", feature = "array"))]
+test_type!(timestamptz_array(PostgreSql, "timestamptz[]", {
+    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+    Value::array(vec![dt.with_timezone(&chrono::Utc)])
+}));
+
+/* Reserved for SQLx. All of these are broken in the current impl!
+#[cfg(feature = "chrono-0_4")]
+test_type!(timetz(PostgreSql, "timetz", {
+    let dt = chrono::DateTime::parse_from_rfc3339("1970-01-01T19:10:22Z").unwrap();
+    Value::time(chrono::NaiveTime::from_hms(19, 10, 22))
+}));
+
+#[cfg(all(feature = "chrono-0_4", feature = "array"))]
+test_type!(timetz_array(PostgreSql, "timetz[]", {
+    let dt = chrono::DateTime::parse_from_rfc3339("1970-01-01T19:10:22Z").unwrap();
+    Value::array(vec![dt.with_timezone(&chrono::Utc)])
+}));
+
+test_type!(cidr(PostgreSql, "cidr", Value::text("0.0.0.0/0")));
+
+#[cfg(feature = "array")]
+test_type!(cidr_array(
+    PostgreSql,
+    "cidr[]",
+    Value::array(vec![Value::text("127.0.0.1/16"), Value::text("192.168.1.1/24")])
+));
+
+test_type!(bytea(PostgreSql, "bytea", Value::bytes(b"DEADBEEF".to_vec())));
+
+#[cfg(feature = "array")]
+test_type!(bytea_array(
+    PostgreSql,
+    "bytea[]",
+    Value::array(vec![
+        Value::bytes(b"DEADBEEF".to_vec()),
+        Value::bytes(b"BEEFBEEF".to_vec())
+    ])
+));
+
+#[cfg(all(feature = "uuid-0_8", feature = "array"))]
+test_type!(uuid_array(
+    PostgreSql,
+    "uuid[]",
+    Value::array(vec![
+        uuid::Uuid::from_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8").unwrap()
+    ])
+));
+
+*/

--- a/src/tests/type_test.rs
+++ b/src/tests/type_test.rs
@@ -1,0 +1,12 @@
+use crate::single::Quaint;
+
+#[async_trait::async_trait]
+pub trait TypeTest {
+    async fn new() -> crate::Result<Self>
+    where
+        Self: Sized;
+
+    async fn create_table(&mut self, r#type: &str) -> crate::Result<String>;
+
+    fn conn(&self) -> &Quaint;
+}


### PR DESCRIPTION
This adds infra to test type conversions from and to the database. The first batch adds tests for PostgreSQL and MySQL, next: SQL Server and SQLite.

Some tests are commented out due to us not really handling them right here. They work much nicer in SQLx, so I just keep them commented on `master` and rebase the sqlx branch.