### PR TITLE
Implement possibility to use multiple table-likes in FROM.

### DIFF
--- a/src/ast/select.rs
+++ b/src/ast/select.rs
@@ -112,7 +112,7 @@ impl<'a> Select<'a> {
     /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
     /// # fn main() -> Result<(), quaint::error::Error> {
     /// let query = Select::from_table("users")
-    ///     .from(Table::from(Select::default().value(1)).alias("num"))
+    ///     .and_from(Table::from(Select::default().value(1)).alias("num"))
     ///     .column(("users", "name"))
     ///     .value(Table::from("num").asterisk());
     ///
@@ -122,7 +122,7 @@ impl<'a> Select<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from<T>(mut self, table: T) -> Self
+    pub fn and_from<T>(mut self, table: T) -> Self
     where
         T: Into<Table<'a>>,
     {

--- a/src/ast/select.rs
+++ b/src/ast/select.rs
@@ -4,7 +4,7 @@ use crate::ast::*;
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Select<'a> {
     pub(crate) distinct: bool,
-    pub(crate) table: Option<Box<Table<'a>>>,
+    pub(crate) tables: Vec<Box<Table<'a>>>,
     pub(crate) columns: Vec<Expression<'a>>,
     pub(crate) conditions: Option<ConditionTree<'a>>,
     pub(crate) ordering: Ordering<'a>,
@@ -101,9 +101,33 @@ impl<'a> Select<'a> {
         T: Into<Table<'a>>,
     {
         Select {
-            table: Some(Box::new(table.into())),
+            tables: vec![Box::new(table.into())],
             ..Default::default()
         }
+    }
+
+    /// Adds a table to be selected.
+    ///
+    /// ```rust
+    /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
+    /// # fn main() -> Result<(), quaint::error::Error> {
+    /// let query = Select::from_table("users")
+    ///     .from(Table::from(Select::default().value(1)).alias("num"))
+    ///     .column(("users", "name"))
+    ///     .value(Table::from("num").asterisk());
+    ///
+    /// let (sql, _) = Sqlite::build(query)?;
+    ///
+    /// assert_eq!("SELECT `users`.`name`, `num`.* FROM `users`, (SELECT ?) AS `num`", sql);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from<T>(mut self, table: T) -> Self
+    where
+        T: Into<Table<'a>>,
+    {
+        self.tables.push(Box::new(table.into()));
+        self
     }
 
     /// Selects a static value as the column.

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -1220,4 +1220,17 @@ mod tests {
 
         assert_eq!(expected_sql, sql);
     }
+
+    #[test]
+    fn test_from() {
+        let expected_sql = "SELECT [foo].*, [bar].[a] FROM [foo], (SELECT [a] FROM [baz]) AS [bar]";
+        let query = Select::default()
+            .from("foo")
+            .from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
+            .value(Table::from("foo").asterisk())
+            .column(("bar", "a"));
+
+        let (sql, _) = Mssql::build(query).unwrap();
+        assert_eq!(expected_sql, sql);
+    }
 }

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -1225,8 +1225,8 @@ mod tests {
     fn test_from() {
         let expected_sql = "SELECT [foo].*, [bar].[a] FROM [foo], (SELECT [a] FROM [baz]) AS [bar]";
         let query = Select::default()
-            .from("foo")
-            .from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
+            .and_from("foo")
+            .and_from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
             .value(Table::from("foo").asterisk())
             .column(("bar", "a"));
 

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -480,6 +480,19 @@ mod tests {
     }
 
     #[test]
+    fn test_from() {
+        let expected_sql = "SELECT `foo`.*, `bar`.`a` FROM `foo`, (SELECT `a` FROM `baz`) AS `bar`";
+        let query = Select::default()
+            .from("foo")
+            .from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
+            .value(Table::from("foo").asterisk())
+            .column(("bar", "a"));
+
+        let (sql, _) = Mysql::build(query).unwrap();
+        assert_eq!(expected_sql, sql);
+    }
+
+    #[test]
     #[cfg(feature = "json-1")]
     fn test_raw_json() {
         let (sql, params) = Mysql::build(Select::default().value(serde_json::json!({ "foo": "bar" }).raw())).unwrap();

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -483,8 +483,8 @@ mod tests {
     fn test_from() {
         let expected_sql = "SELECT `foo`.*, `bar`.`a` FROM `foo`, (SELECT `a` FROM `baz`) AS `bar`";
         let query = Select::default()
-            .from("foo")
-            .from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
+            .and_from("foo")
+            .and_from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
             .value(Table::from("foo").asterisk())
             .column(("bar", "a"));
 

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -369,6 +369,19 @@ mod tests {
         assert_eq!(expected_sql, sql);
     }
 
+    #[test]
+    fn test_from() {
+        let expected_sql = "SELECT \"foo\".*, \"bar\".\"a\" FROM \"foo\", (SELECT \"a\" FROM \"baz\") AS \"bar\"";
+        let query = Select::default()
+            .from("foo")
+            .from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
+            .value(Table::from("foo").asterisk())
+            .column(("bar", "a"));
+
+        let (sql, _) = Postgres::build(query).unwrap();
+        assert_eq!(expected_sql, sql);
+    }
+
     #[cfg(feature = "json-1")]
     #[test]
     fn equality_with_a_json_value() {

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -373,8 +373,8 @@ mod tests {
     fn test_from() {
         let expected_sql = "SELECT \"foo\".*, \"bar\".\"a\" FROM \"foo\", (SELECT \"a\" FROM \"baz\") AS \"bar\"";
         let query = Select::default()
-            .from("foo")
-            .from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
+            .and_from("foo")
+            .and_from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
             .value(Table::from("foo").asterisk())
             .column(("bar", "a"));
 

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -607,6 +607,19 @@ mod tests {
         assert_eq!(expected_sql, sql);
     }
 
+    #[test]
+    fn test_from() {
+        let expected_sql = "SELECT `foo`.*, `bar`.`a` FROM `foo`, (SELECT `a` FROM `baz`) AS `bar`";
+        let query = Select::default()
+            .from("foo")
+            .from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
+            .value(Table::from("foo").asterisk())
+            .column(("bar", "a"));
+
+        let (sql, _) = Sqlite::build(query).unwrap();
+        assert_eq!(expected_sql, sql);
+    }
+
     #[cfg(feature = "sqlite")]
     fn sqlite_harness() -> ::rusqlite::Connection {
         let conn = ::rusqlite::Connection::open_in_memory().unwrap();

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -611,8 +611,8 @@ mod tests {
     fn test_from() {
         let expected_sql = "SELECT `foo`.*, `bar`.`a` FROM `foo`, (SELECT `a` FROM `baz`) AS `bar`";
         let query = Select::default()
-            .from("foo")
-            .from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
+            .and_from("foo")
+            .and_from(Table::from(Select::from_table("baz").column("a")).alias("bar"))
             .value(Table::from("foo").asterisk())
             .column(("bar", "a"));
 


### PR DESCRIPTION
- Adds `.from` to select.
- Changes `table` in `Select` to `tables` and makes it a vector of tables instead of an option of a single table.