### PR TITLE
Add raw comparators

### DIFF
--- a/src/ast/compare.rs
+++ b/src/ast/compare.rs
@@ -452,7 +452,7 @@ pub trait Comparable<'a> {
         T: Into<Expression<'a>>,
         V: Into<Expression<'a>>;
 
-    /// Tests if the value is not between two given values.
+    /// Compares two expressions with a custom operator.
     ///
     /// ```rust
     /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};

--- a/src/ast/compare.rs
+++ b/src/ast/compare.rs
@@ -2,7 +2,7 @@ use super::ExpressionKind;
 use crate::ast::{Column, ConditionTree, Expression};
 use std::borrow::Cow;
 
-/// For modeling comparison expression
+/// For modeling comparison expressions.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Compare<'a> {
     /// `left = right`
@@ -41,6 +41,9 @@ pub enum Compare<'a> {
     Between(Box<Expression<'a>>, Box<Expression<'a>>, Box<Expression<'a>>),
     /// `value` NOT BETWEEN `left` AND `right`
     NotBetween(Box<Expression<'a>>, Box<Expression<'a>>, Box<Expression<'a>>),
+    /// Raw comparator, allows to use an operator `left <raw> right` as is,
+    /// without visitor transformation in between.
+    Raw(Box<Expression<'a>>, Cow<'a, str>, Box<Expression<'a>>),
 }
 
 impl<'a> From<Compare<'a>> for ConditionTree<'a> {
@@ -448,6 +451,27 @@ pub trait Comparable<'a> {
     where
         T: Into<Expression<'a>>,
         V: Into<Expression<'a>>;
+
+    /// Tests if the value is not between two given values.
+    ///
+    /// ```rust
+    /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
+    /// # fn main() -> Result<(), quaint::error::Error> {
+    /// let query = Select::from_table("users").so_that("foo".compare_raw("ILIKE", "%bar%"));
+    /// let (sql, params) = Sqlite::build(query)?;
+    ///
+    /// assert_eq!("SELECT `users`.* FROM `users` WHERE `foo` ILIKE ?", sql);
+    ///
+    /// assert_eq!(vec![
+    ///     Value::from("%bar%"),
+    /// ], params);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn compare_raw<T, V>(self, raw_comparator: T, right: V) -> Compare<'a>
+    where
+        T: Into<Cow<'a, str>>,
+        V: Into<Expression<'a>>;
 }
 
 impl<'a, U> Comparable<'a> for U
@@ -611,5 +635,17 @@ where
         let col: Column<'a> = self.into();
         let val: Expression<'a> = col.into();
         val.not_between(left, right)
+    }
+
+    fn compare_raw<T, V>(self, raw_comparator: T, right: V) -> Compare<'a>
+    where
+        T: Into<Cow<'a, str>>,
+        V: Into<Expression<'a>>,
+    {
+        let left: Column<'a> = self.into();
+        let left: Expression<'a> = left.into();
+        let right: Expression<'a> = right.into();
+
+        left.compare_raw(raw_comparator.into(), right)
     }
 }

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -241,4 +241,12 @@ impl<'a> Comparable<'a> for Expression<'a> {
     {
         Compare::NotBetween(Box::new(self), Box::new(left.into()), Box::new(right.into()))
     }
+
+    fn compare_raw<T, V>(self, raw_comparator: T, right: V) -> Compare<'a>
+    where
+        T: Into<Cow<'a, str>>,
+        V: Into<Expression<'a>>,
+    {
+        Compare::Raw(Box::new(self), raw_comparator.into(), Box::new(right.into()))
+    }
 }

--- a/src/ast/row.rs
+++ b/src/ast/row.rs
@@ -285,4 +285,13 @@ impl<'a> Comparable<'a> for Row<'a> {
         let value: Expression<'a> = self.into();
         value.not_between(left, right)
     }
+
+    fn compare_raw<T, V>(self, raw_comparator: T, right: V) -> Compare<'a>
+    where
+        T: Into<Cow<'a, str>>,
+        V: Into<Expression<'a>>,
+    {
+        let value: Expression<'a> = self.into();
+        value.compare_raw(raw_comparator, right)
+    }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -746,7 +746,9 @@ pub trait Visitor<'a> {
             }
             Compare::Raw(left, comp, right) => {
                 self.visit_expression(*left)?;
-                self.write(format!(" {} ", comp))?;
+                self.write(" ")?;
+                self.write(comp)?;
+                self.write(" ")?;
                 self.visit_expression(*right)
             }
         }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -744,6 +744,11 @@ pub trait Visitor<'a> {
                 self.write(" AND ")?;
                 self.visit_expression(*right)
             }
+            Compare::Raw(left, comp, right) => {
+                self.visit_expression(*left)?;
+                self.write(format!(" {} ", comp))?;
+                self.visit_expression(*right)
+            }
         }
     }
 

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -495,4 +495,12 @@ mod tests {
         assert_eq!(format!("SELECT '{}'", dt.to_rfc3339(),), sql);
         assert!(params.is_empty());
     }
+
+    #[test]
+    fn test_raw_comparator() {
+        let (sql, params) =
+            Postgres::build(Select::from_table("foo").so_that("bar".compare_raw("ILIKE", "baz%"))).unwrap();
+
+        assert_eq!(r#"SELECT "foo".* FROM "foo" WHERE "bar" ILIKE $1"#, sql);
+    }
 }


### PR DESCRIPTION
Allows to inject unsupported comparators as raw values: `col.compare_raw("ILIKE", "foo%")`