### PR TITLE
Log if the query was successful (or not)

### DIFF
--- a/src/connector/metrics.rs
+++ b/src/connector/metrics.rs
@@ -16,12 +16,18 @@ where
     let end = Instant::now();
 
     if *crate::LOG_QUERIES {
+        let result = match res {
+            Ok(_) => "success",
+            Err(_) => "error",
+        };
+
         #[cfg(not(feature = "tracing-log"))]
         {
             info!(
-                "query: \"{}\", params: {} (in {}ms)",
+                "query: \"{}\", params: {} ({} in {}ms)",
                 query,
                 Params(params),
+                result,
                 start.elapsed().as_millis(),
             );
         }
@@ -32,6 +38,7 @@ where
                 item_type = "query",
                 params = %Params(params),
                 duration_ms = start.elapsed().as_millis() as u64,
+                result,
             )
         }
     }


### PR DESCRIPTION
Needs to have `LOG_QUERIES` set to `1` to be visible.

With tracing, adds a new key `result`, with a possible value `success` or `error` to the query log.

Without tracing, changes the rendering to either:

```
query: "SELECT 1", params: [] (success in 0ms)
```

or:

```
query: "SELECT aseas", params: [] (error in 0ms)
```

Closes https://github.com/prisma/prisma-engines/issues/879