### PR TITLE
Fix of precision when storing/loading floats

### DIFF
--- a/src/connector/mysql/conversion.rs
+++ b/src/connector/mysql/conversion.rs
@@ -9,7 +9,6 @@ use mysql_async::{
     self as my,
     consts::{ColumnFlags, ColumnType},
 };
-use rust_decimal::prelude::ToPrimitive;
 use std::convert::TryFrom;
 
 pub fn conv_params<'a>(params: &[Value<'a>]) -> crate::Result<my::Params> {
@@ -25,7 +24,7 @@ pub fn conv_params<'a>(params: &[Value<'a>]) -> crate::Result<my::Params> {
                 Value::Integer(i) => i.map(|i| my::Value::Int(i)),
                 Value::Real(f) => match f {
                     Some(f) => {
-                        let floating = f.to_f64().ok_or_else(|| {
+                        let floating = f.to_string().parse::<f64>().map_err(|_| {
                             let msg = "Decimal is not a f64.";
                             let kind = ErrorKind::conversion(msg);
 

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -464,7 +464,7 @@ impl<'a> ToSql for Value<'a> {
                 f.to_sql(ty, out)
             }),
             (Value::Real(decimal), &PostgresType::FLOAT8) => decimal.map(|decimal| {
-                let f = decimal.to_f64().expect("decimal to f64 conversion");
+                let f = decimal.to_string().parse::<f64>().expect("decimal to f64 conversion");
                 f.to_sql(ty, out)
             }),
             (Value::Array(decimals), &PostgresType::FLOAT4_ARRAY) => decimals.as_ref().map(|decimals| {
@@ -477,7 +477,10 @@ impl<'a> ToSql for Value<'a> {
             (Value::Array(decimals), &PostgresType::FLOAT8_ARRAY) => decimals.as_ref().map(|decimals| {
                 let f: Vec<f64> = decimals
                     .into_iter()
-                    .filter_map(|v| v.as_decimal().and_then(|decimal| decimal.to_f64()))
+                    .filter_map(|v| {
+                        v.as_decimal()
+                            .and_then(|decimal| decimal.to_string().parse::<f64>().ok())
+                    })
                     .collect();
                 f.to_sql(ty, out)
             }),

--- a/src/connector/sqlite/conversion.rs
+++ b/src/connector/sqlite/conversion.rs
@@ -10,7 +10,6 @@ use rusqlite::{
     types::{Null, ToSql, ToSqlOutput, ValueRef},
     Column, Error as RusqlError, Row as SqliteRow, Rows as SqliteRows,
 };
-use rust_decimal::prelude::ToPrimitive;
 
 impl TypeIdentifier for Column<'_> {
     fn is_real(&self) -> bool {
@@ -171,7 +170,9 @@ impl<'a> ToSql for Value<'a> {
     fn to_sql(&self) -> Result<ToSqlOutput, RusqlError> {
         let value = match self {
             Value::Integer(integer) => integer.map(|i| ToSqlOutput::from(i)),
-            Value::Real(d) => d.map(|d| ToSqlOutput::from(d.to_f64().expect("Decimal is not a f64."))),
+            Value::Real(d) => {
+                d.map(|d| ToSqlOutput::from(d.to_string().parse::<f64>().expect("Decimal is not a f64.")))
+            }
             Value::Text(cow) => cow.as_ref().map(|cow| ToSqlOutput::from(cow.as_ref())),
             Value::Enum(cow) => cow.as_ref().map(|cow| ToSqlOutput::from(cow.as_ref())),
             Value::Boolean(boo) => boo.map(|boo| ToSqlOutput::from(boo)),

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -104,8 +104,6 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
     type Error = DeserializeError;
 
     fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-        use rust_decimal::prelude::ToPrimitive;
-
         match self.0 {
             Value::Text(Some(s)) => visitor.visit_string(s.into_owned()),
             Value::Text(None) => visitor.visit_none(),
@@ -119,7 +117,7 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
             Value::Boolean(None) => visitor.visit_none(),
             Value::Char(Some(c)) => visitor.visit_char(c),
             Value::Char(None) => visitor.visit_none(),
-            Value::Real(Some(real)) => visitor.visit_f64(real.to_f64().unwrap()),
+            Value::Real(Some(real)) => visitor.visit_f64(real.to_string().parse::<f64>().unwrap()),
             Value::Real(None) => visitor.visit_none(),
 
             #[cfg(feature = "uuid-0_8")]


### PR DESCRIPTION
The rust_decimal has changed their floating point conversion that has
tendency to lose precision in some cases. We now take the approach of
going from Decimal -> String -> f64, which is slower but keeps the precision.