### PR TITLE
Count rows correctly when converting tuples

### DIFF
--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -271,6 +271,7 @@ impl<'a> Visitor<'a> for Mssql<'a> {
     // MSSQL doesn't support tuples, we do AND/OR.
     fn visit_multiple_tuple_comparison(&mut self, left: Row<'a>, right: Values<'a>, negate: bool) -> visitor::Result {
         let row_len = left.len();
+        let values_len = right.len();
 
         if negate {
             self.write("NOT ")?;
@@ -294,7 +295,7 @@ impl<'a> Visitor<'a> for Mssql<'a> {
                     Ok(())
                 })?;
 
-                if i < row_len - 1 {
+                if i < values_len - 1 {
                     this.write(" OR ")?;
                 }
             }


### PR DESCRIPTION
This created faulty queries, such as `((foo = 1 AND bar = 2) OR)`.