### PR TITLE
Fixing uri parsing until we get the connection-string crate

### DIFF
--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -329,7 +329,7 @@ impl MssqlUrl {
 
         match parts.next() {
             Some(host_part) => {
-                let url = Url::parse(host_part)?;
+                let url = Url::parse(&host_part.replace("jdbc:sqlserver://", "sqlserver://"))?;
 
                 let params: crate::Result<HashMap<String, String>> = parts
                     .filter(|kv| kv != &"")


### PR DESCRIPTION
Url doesn't recognize the hostname if the scheme contains `:`...