### PR TITLE
Run clippy auto fixes

### DIFF
--- a/src/ast/table.rs
+++ b/src/ast/table.rs
@@ -99,7 +99,7 @@ impl<'a> Table<'a> {
                 IndexDefinition::Single(column) => {
                     if let Some(right_cond) = join_cond(&column)? {
                         match result {
-                            ConditionTree::NegativeCondition => result = right_cond.into(),
+                            ConditionTree::NegativeCondition => result = right_cond,
                             left_cond => result = left_cond.or(right_cond),
                         }
                     }
@@ -117,7 +117,7 @@ impl<'a> Table<'a> {
                     }
 
                     match result {
-                        ConditionTree::NegativeCondition => result = sub_result.into(),
+                        ConditionTree::NegativeCondition => result = sub_result,
                         left_cond => result = left_cond.or(sub_result),
                     }
                 }

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -383,10 +383,7 @@ impl<'a> Value<'a> {
 
     /// `true` if the `Value` is an integer.
     pub fn is_integer(&self) -> bool {
-        match self {
-            Value::Integer(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Integer(_))
     }
 
     /// Returns an i64 if the value is an integer, otherwise `None`.
@@ -399,10 +396,7 @@ impl<'a> Value<'a> {
 
     /// `true` if the `Value` is a real value.
     pub fn is_real(&self) -> bool {
-        match self {
-            Value::Real(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Real(_))
     }
 
     /// Returns a f64 if the value is a real value and the underlying decimal can be converted, otherwise `None`.
@@ -416,7 +410,7 @@ impl<'a> Value<'a> {
     /// Returns a decimal if the value is a real value, otherwise `None`.
     pub fn as_decimal(&self) -> Option<Decimal> {
         match self {
-            Value::Real(d) => d.clone(),
+            Value::Real(d) => *d,
             _ => None,
         }
     }
@@ -434,7 +428,7 @@ impl<'a> Value<'a> {
     /// Returns a bool if the value is a boolean, otherwise `None`.
     pub fn as_bool(&self) -> Option<bool> {
         match self {
-            Value::Boolean(b) => b.clone(),
+            Value::Boolean(b) => *b,
             // For schemas which don't tag booleans
             Value::Integer(Some(i)) if *i == 0 || *i == 1 => Some(*i == 1),
             _ => None,
@@ -444,26 +438,20 @@ impl<'a> Value<'a> {
     /// `true` if the `Value` is an Array.
     #[cfg(feature = "array")]
     pub fn is_array(&self) -> bool {
-        match self {
-            Value::Array(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Array(_))
     }
 
     /// `true` if the `Value` is of UUID type.
     #[cfg(feature = "uuid-0_8")]
     pub fn is_uuid(&self) -> bool {
-        match self {
-            Value::Uuid(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Uuid(_))
     }
 
     /// Returns an UUID if the value is of UUID type, otherwise `None`.
     #[cfg(feature = "uuid-0_8")]
     pub fn as_uuid(&self) -> Option<Uuid> {
         match self {
-            Value::Uuid(u) => u.clone(),
+            Value::Uuid(u) => *u,
             _ => None,
         }
     }
@@ -471,17 +459,14 @@ impl<'a> Value<'a> {
     /// `true` if the `Value` is a DateTime.
     #[cfg(feature = "chrono-0_4")]
     pub fn is_datetime(&self) -> bool {
-        match self {
-            Value::DateTime(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::DateTime(_))
     }
 
     /// Returns a `DateTime` if the value is a `DateTime`, otherwise `None`.
     #[cfg(feature = "chrono-0_4")]
     pub fn as_datetime(&self) -> Option<DateTime<Utc>> {
         match self {
-            Value::DateTime(dt) => dt.clone(),
+            Value::DateTime(dt) => *dt,
             _ => None,
         }
     }
@@ -489,17 +474,14 @@ impl<'a> Value<'a> {
     /// `true` if the `Value` is a Date.
     #[cfg(feature = "chrono-0_4")]
     pub fn is_date(&self) -> bool {
-        match self {
-            Value::Date(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Date(_))
     }
 
     /// Returns a `NaiveDate` if the value is a `Date`, otherwise `None`.
     #[cfg(feature = "chrono-0_4")]
     pub fn as_date(&self) -> Option<NaiveDate> {
         match self {
-            Value::Date(dt) => dt.clone(),
+            Value::Date(dt) => *dt,
             _ => None,
         }
     }
@@ -507,17 +489,14 @@ impl<'a> Value<'a> {
     /// `true` if the `Value` is a `Time`.
     #[cfg(feature = "chrono-0_4")]
     pub fn is_time(&self) -> bool {
-        match self {
-            Value::Time(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Time(_))
     }
 
     /// Returns a `NaiveTime` if the value is a `Time`, otherwise `None`.
     #[cfg(feature = "chrono-0_4")]
     pub fn as_time(&self) -> Option<NaiveTime> {
         match self {
-            Value::Time(time) => time.clone(),
+            Value::Time(time) => *time,
             _ => None,
         }
     }
@@ -525,10 +504,7 @@ impl<'a> Value<'a> {
     /// `true` if the `Value` is a JSON value.
     #[cfg(feature = "json-1")]
     pub fn is_json(&self) -> bool {
-        match self {
-            Value::Json(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Json(_))
     }
 
     /// Returns a reference to a JSON Value if of Json type, otherwise `None`.

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -154,7 +154,7 @@ impl<'a> From<Value<'a>> for serde_json::Value {
             Value::Text(cow) => cow.map(|cow| serde_json::Value::String(cow.into_owned())),
             Value::Bytes(bytes) => bytes.map(|bytes| serde_json::Value::String(base64::encode(&bytes))),
             Value::Enum(cow) => cow.map(|cow| serde_json::Value::String(cow.into_owned())),
-            Value::Boolean(b) => b.map(|b| serde_json::Value::Bool(b)),
+            Value::Boolean(b) => b.map(serde_json::Value::Bool),
             Value::Char(c) => c.map(|c| {
                 let bytes = [c as u8];
                 let s = std::str::from_utf8(&bytes)
@@ -319,10 +319,7 @@ impl<'a> Value<'a> {
 
     /// `true` if the `Value` is text.
     pub fn is_text(&self) -> bool {
-        match self {
-            Value::Text(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Text(_))
     }
 
     /// Returns a &str if the value is text, otherwise `None`.
@@ -337,7 +334,7 @@ impl<'a> Value<'a> {
     /// Returns a char if the value is a char, otherwise `None`.
     pub fn as_char(&self) -> Option<char> {
         match self {
-            Value::Char(c) => c.clone(),
+            Value::Char(c) => *c,
             _ => None,
         }
     }
@@ -363,10 +360,7 @@ impl<'a> Value<'a> {
 
     /// Returns whether this value is the `Bytes` variant.
     pub fn is_bytes(&self) -> bool {
-        match self {
-            Value::Bytes(_) => true,
-            _ => false,
-        }
+        matches!(self, Value::Bytes(_))
     }
 
     /// Returns a bytes slice if the value is text or a byte slice, otherwise `None`.
@@ -398,7 +392,7 @@ impl<'a> Value<'a> {
     /// Returns an i64 if the value is an integer, otherwise `None`.
     pub fn as_i64(&self) -> Option<i64> {
         match self {
-            Value::Integer(i) => i.clone(),
+            Value::Integer(i) => *i,
             _ => None,
         }
     }

--- a/src/connector/connection_info.rs
+++ b/src/connector/connection_info.rs
@@ -52,7 +52,7 @@ impl ConnectionInfo {
 
                     return Ok(ConnectionInfo::Sqlite {
                         file_path: params.file_path,
-                        db_name: params.db_name.clone(),
+                        db_name: params.db_name,
                     });
                 }
             }

--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -179,15 +179,15 @@ impl MssqlQueryParams {
     }
 
     fn host(&self) -> &str {
-        self.host.as_ref().map(|s| s.as_str()).unwrap_or("localhost")
+        self.host.as_deref().unwrap_or("localhost")
     }
 
     fn user(&self) -> Option<&str> {
-        self.user.as_ref().map(|s| s.as_str())
+        self.user.as_deref()
     }
 
     fn password(&self) -> Option<&str> {
-        self.password.as_ref().map(|s| s.as_str())
+        self.password.as_deref()
     }
 
     fn database(&self) -> &str {
@@ -368,7 +368,7 @@ impl MssqlUrl {
 
                 let params: crate::Result<HashMap<String, String>> = parts
                     .filter(|kv| kv != &"")
-                    .map(|kv| kv.split("="))
+                    .map(|kv| kv.split('='))
                     .map(|mut split| {
                         let key = split
                             .next()

--- a/src/connector/mssql/conversion.rs
+++ b/src/connector/mssql/conversion.rs
@@ -17,7 +17,7 @@ pub fn conv_params<'a>(params: &'a [Value<'a>]) -> crate::Result<Vec<&'a dyn ToS
             let mut builder = Error::builder(kind);
             builder.set_original_message(msg);
 
-            Err(builder.build())?
+            return Err(builder.build())
         } else {
             converted.push(param as &dyn ToSql)
         }

--- a/src/connector/mssql/error.rs
+++ b/src/connector/mssql/error.rs
@@ -54,7 +54,7 @@ impl From<tiberius::error::Error> for Error {
                     .split(' ')
                     .last()
                     .unwrap()
-                    .split("'")
+                    .split('\'')
                     .nth(1)
                     .unwrap();
 
@@ -70,13 +70,12 @@ impl From<tiberius::error::Error> for Error {
             tiberius::error::Error::Server(e) if e.code() == 547 => {
                 let index = e
                     .message()
-                    .split('.')
-                    .nth(0)
+                    .split('.').next()
                     .unwrap()
                     .split_whitespace()
                     .last()
                     .unwrap()
-                    .split("\"")
+                    .split('\"')
                     .nth(1)
                     .unwrap();
 
@@ -95,7 +94,7 @@ impl From<tiberius::error::Error> for Error {
                 let index = splitted.nth(1).unwrap().to_string();
 
                 let mut builder = Error::builder(ErrorKind::UniqueConstraintViolation {
-                    constraint: DatabaseConstraint::Index(index.to_string()),
+                    constraint: DatabaseConstraint::Index(index),
                 });
 
                 builder.set_original_code(format!("{}", e.code()));
@@ -116,7 +115,7 @@ impl From<tiberius::error::Error> for Error {
                 let column_name = e.message().split('\'').nth(3).unwrap().to_string();
 
                 let mut builder = Error::builder(ErrorKind::LengthMismatch {
-                    column: Some(column_name.to_owned()),
+                    column: Some(column_name),
                 });
 
                 builder.set_original_code(format!("{}", e.code()));

--- a/src/connector/mysql/conversion.rs
+++ b/src/connector/mysql/conversion.rs
@@ -21,7 +21,7 @@ pub fn conv_params<'a>(params: &[Value<'a>]) -> crate::Result<my::Params> {
 
         for pv in params {
             let res = match pv {
-                Value::Integer(i) => i.map(|i| my::Value::Int(i)),
+                Value::Integer(i) => i.map(my::Value::Int),
                 Value::Real(f) => match f {
                     Some(f) => {
                         let floating = f.to_string().parse::<f64>().map_err(|_| {
@@ -63,7 +63,7 @@ pub fn conv_params<'a>(params: &[Value<'a>]) -> crate::Result<my::Params> {
                     let mut builder = Error::builder(kind);
                     builder.set_original_message(msg);
 
-                    Err(builder.build())?
+                    return Err(builder.build())
                 }
                 #[cfg(feature = "uuid-0_8")]
                 Value::Uuid(u) => u.map(|u| my::Value::Bytes(u.to_hyphenated().to_string().into_bytes())),
@@ -212,7 +212,7 @@ impl TakeRow for my::Row {
                 // JSON is returned as bytes.
                 #[cfg(feature = "json-1")]
                 my::Value::Bytes(b) if column.is_json() => {
-                    serde_json::from_slice(&b).map(|val| Value::json(val)).map_err(|_| {
+                    serde_json::from_slice(&b).map(Value::json).map_err(|_| {
                         let msg = "Unable to convert bytes to JSON";
                         let kind = ErrorKind::conversion(msg);
 
@@ -262,7 +262,7 @@ impl TakeRow for my::Row {
                             column.name_str()
                         );
                         let kind = ErrorKind::value_out_of_range(msg);
-                        Err(Error::builder(kind).build())?;
+                        return Err(Error::builder(kind).build());
                     }
 
                     let time = NaiveTime::from_hms_micro(hour.into(), min.into(), sec.into(), micro);
@@ -276,12 +276,12 @@ impl TakeRow for my::Row {
                 my::Value::Time(is_neg, days, hours, minutes, seconds, micros) => {
                     if is_neg {
                         let kind = ErrorKind::conversion("Failed to convert a negative time");
-                        Err(Error::builder(kind).build())?
+                        return Err(Error::builder(kind).build())
                     }
 
                     if days != 0 {
                         let kind = ErrorKind::conversion("Failed to read a MySQL `time` as duration");
-                        Err(Error::builder(kind).build())?
+                        return Err(Error::builder(kind).build())
                     }
 
                     let time = NaiveTime::from_hms_micro(hours.into(), minutes.into(), seconds.into(), micros);
@@ -310,7 +310,7 @@ impl TakeRow for my::Row {
                         );
 
                         let kind = ErrorKind::conversion(msg);
-                        Err(Error::builder(kind).build())?
+                        return Err(Error::builder(kind).build())
                     }
                 },
                 #[cfg(not(feature = "chrono-0_4"))]

--- a/src/connector/mysql/error.rs
+++ b/src/connector/mysql/error.rs
@@ -12,7 +12,7 @@ impl From<my::Error> for Error {
                 let splitted: Vec<&str> = message.split_whitespace().collect();
                 let splitted: Vec<&str> = splitted.last().map(|s| s.split('\'').collect()).unwrap();
 
-                let index = splitted[1].split(".").last().unwrap().to_string();
+                let index = splitted[1].split('.').last().unwrap().to_string();
 
                 let mut builder = Error::builder(ErrorKind::UniqueConstraintViolation {
                     constraint: DatabaseConstraint::Index(index),

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -122,7 +122,7 @@ impl SslParams {
                 })
                 .build()
             })?;
-            let password = self.identity_password.0.as_ref().map(|s| s.as_str()).unwrap_or("");
+            let password = self.identity_password.0.as_deref().unwrap_or("");
             let identity = Identity::from_pkcs12(&db, &password)?;
 
             auth.identity(identity);

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -29,7 +29,7 @@ struct XmlString(pub String);
 
 impl<'a> FromSql<'a> for XmlString {
     fn from_sql(_ty: &PostgresType, raw: &'a [u8]) -> Result<XmlString, Box<dyn std::error::Error + Sync + Send>> {
-        Ok(XmlString(String::from_utf8(raw.to_owned()).unwrap().into()))
+        Ok(XmlString(String::from_utf8(raw.to_owned()).unwrap()))
     }
 
     fn accepts(ty: &PostgresType) -> bool {
@@ -44,7 +44,7 @@ struct EnumString {
 impl<'a> FromSql<'a> for EnumString {
     fn from_sql(_ty: &PostgresType, raw: &'a [u8]) -> Result<EnumString, Box<dyn std::error::Error + Sync + Send>> {
         Ok(EnumString {
-            value: String::from_utf8(raw.to_owned()).unwrap().into(),
+            value: String::from_utf8(raw.to_owned()).unwrap(),
         })
     }
 
@@ -513,14 +513,14 @@ impl<'a> ToSql for Value<'a> {
             }),
             (Value::Array(decimals), &PostgresType::FLOAT4_ARRAY) => decimals.as_ref().map(|decimals| {
                 let f: Vec<f32> = decimals
-                    .into_iter()
+                    .iter()
                     .filter_map(|v| v.as_decimal().and_then(|decimal| decimal.to_f32()))
                     .collect();
                 f.to_sql(ty, out)
             }),
             (Value::Array(decimals), &PostgresType::FLOAT8_ARRAY) => decimals.as_ref().map(|decimals| {
                 let f: Vec<f64> = decimals
-                    .into_iter()
+                    .iter()
                     .filter_map(|v| {
                         v.as_decimal()
                             .and_then(|decimal| decimal.to_string().parse::<f64>().ok())
@@ -648,7 +648,7 @@ fn string_to_bits(s: &str) -> crate::Result<BitVec> {
                 let msg = "Unexpected character for bits input. Expected only 1 and 0.";
                 let kind = ErrorKind::conversion(msg);
 
-                Err(Error::builder(kind).build())?
+                return Err(Error::builder(kind).build())
             }
         }
     }

--- a/src/connector/sqlite/conversion.rs
+++ b/src/connector/sqlite/conversion.rs
@@ -118,7 +118,7 @@ impl<'a> GetRow for SqliteRow<'a> {
                             let msg = format!("Value {} not supported", n);
                             let kind = ErrorKind::conversion(msg);
 
-                            Err(Error::builder(kind).build())?
+                            return Err(Error::builder(kind).build())
                         }
                         None => Value::Integer(None),
                     },
@@ -212,7 +212,7 @@ impl<'a> ToSql for Value<'a> {
                 let mut builder = Error::builder(kind);
                 builder.set_original_message(msg);
 
-                Err(RusqlError::ToSqlConversionFailure(Box::new(builder.build())))?
+                return Err(RusqlError::ToSqlConversionFailure(Box::new(builder.build())))
             }
             #[cfg(feature = "json-1")]
             Value::Json(value) => value.as_ref().map(|value| {

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,12 +65,12 @@ impl Error {
 
     /// The error code sent by the database, if available.
     pub fn original_code(&self) -> Option<&str> {
-        self.original_code.as_ref().map(|s| s.as_str())
+        self.original_code.as_deref()
     }
 
     /// The original error message sent by the database, if available.
     pub fn original_message(&self) -> Option<&str> {
-        self.original_message.as_ref().map(|s| s.as_str())
+        self.original_message.as_deref()
     }
 
     /// A more specific error type for matching.

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -940,7 +940,7 @@ pub trait Visitor<'a> {
 
         self.visit_column(Column::from(cte.identifier.into_owned()))?;
 
-        if cols.len() > 0 {
+        if !cols.is_empty() {
             self.write(" ")?;
             self.visit_row(Row::from(cols))?;
         }

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -192,7 +192,7 @@ impl<'a> Visitor<'a> for Mssql<'a> {
                 let mut builder = Error::builder(kind);
                 builder.set_original_message(msg);
 
-                Err(builder.build())?
+                return Err(builder.build())
             }
             #[cfg(feature = "uuid-0_8")]
             Value::Uuid(uuid) => uuid.map(|uuid| {

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -80,7 +80,7 @@ impl<'a> Visitor<'a> for Mysql<'a> {
                 let mut builder = Error::builder(kind);
                 builder.set_original_message(msg);
 
-                Err(builder.build())?
+                return Err(builder.build())
             }
             #[cfg(feature = "uuid-0_8")]
             Value::Uuid(uuid) => uuid.map(|uuid| self.write(format!("'{}'", uuid.to_hyphenated().to_string()))),

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -64,7 +64,7 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
                 let mut builder = Error::builder(kind);
                 builder.set_original_message(msg);
 
-                Err(builder.build())?
+                return Err(builder.build())
             }
             #[cfg(feature = "uuid-0_8")]
             Value::Uuid(uuid) => uuid.map(|uuid| self.write(format!("'{}'", uuid.to_hyphenated().to_string()))),


### PR DESCRIPTION
This applies a majority of the clippy lints by running: 
```sh
$ cargo +nightly clippy --fix -Z unstable-options
```

Two lints have not been applied:
- `rc_buffer` which has since been disabled by https://github.com/rust-lang/rust-clippy/pull/6128
- `large_enum_variant` which requires boxing the `Function` member of our `Ast` type. I wasn't sure how to do this, so opted to not to for now.

I think these changes should all be fairly straightforward and easy to merge. Thanks!