### PR TITLE
Use connection-string

### DIFF
--- a/.buildkite/docker.sh
+++ b/.buildkite/docker.sh
@@ -30,7 +30,7 @@ docker run -w /build --network test-net -v $BUILDKITE_BUILD_CHECKOUT_PATH:/build
     -e TEST_MYSQL=mysql://prisma:prisma@test-mysql:3306/prisma \
     -e TEST_MYSQL8=mysql://prisma:prisma@test-mysql-8:3306/prisma \
     -e TEST_PSQL=postgres://prisma:prisma@test-postgres:5432/prisma \
-    -e TEST_MSSQL="sqlserver://test-mssql:1433;user=SA;password=$MSSQL_SA_PASSWORD;trustServerCertificate=true" \
+    -e TEST_MSSQL="jdbc:sqlserver://test-mssql:1433;user=SA;password=$MSSQL_SA_PASSWORD;trustServerCertificate=true" \
     prismagraphql/build:test cargo test --features full,json-1,xml,uuid-0_8,chrono-0_4,tracing-log,serde-support
 
 exit_code=$?

--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
 export TEST_MYSQL="mysql://root:prisma@localhost:3306/prisma"
 export TEST_MYSQL8="mysql://root:prisma@localhost:3307/prisma"
 export TEST_PSQL="postgres://postgres:prisma@localhost:5432/postgres"
-export TEST_MSSQL="sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT"
+export TEST_MSSQL="jdbc:sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;encrypt=DANGER_PLAINTEXT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ mobc = {version = "0.5.7", optional = true}
 serde = {version = "1.0", optional = true}
 tokio = {version = "0.2", features = ["rt-threaded", "macros", "sync"], optional = true}
 tokio-util = {version = "0.3", features = ["compat"], optional = true}
+connection-string = "0.1.5"
 
 [dev-dependencies]
 indoc = "0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -206,6 +206,13 @@ impl From<num::TryFromIntError> for Error {
     }
 }
 
+impl From<connection_string::Error> for Error {
+    fn from(err: connection_string::Error) -> Error {
+        let err = Cow::Owned(format!("{}", err));
+        Self::builder(ErrorKind::ConversionError(err)).build()
+    }
+}
+
 #[cfg(feature = "pooled")]
 impl From<mobc::Error<Error>> for Error {
     fn from(e: mobc::Error<Error>) -> Self {
@@ -246,6 +253,18 @@ impl From<url::ParseError> for Error {
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Error {
         Error::builder(ErrorKind::IoError(e)).build()
+    }
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(_e: std::num::ParseIntError) -> Error {
+        Error::builder(ErrorKind::conversion("Couldn't convert data to an integer")).build()
+    }
+}
+
+impl From<std::str::ParseBoolError> for Error {
+    fn from(_e: std::str::ParseBoolError) -> Error {
+        Error::builder(ErrorKind::conversion("Couldn't convert data to a boolean")).build()
     }
 }
 


### PR DESCRIPTION
Uses `connection-string` for JDBC parsing. This required mutable access to `properties`, so I've pushed `connection-string@0.1.5` which provides access to `properties_mut`.

Also I've made it so the JDBC parser handles errors in the string rather than silently continuing. This should make it easier to debug malformed strings (instead of a param not showing up, we'll return an error if we found one).

`connection-string` doesn't know how to _encode_ anything yet, so I haven't touched the ado.net logic. Hope this is good!