### PR TITLE
Change MySQL decimal conversion to write string instead of f64

### DIFF
--- a/src/connector/mysql/conversion.rs
+++ b/src/connector/mysql/conversion.rs
@@ -24,14 +24,14 @@ pub fn conv_params<'a>(params: &[Value<'a>]) -> crate::Result<my::Params> {
                 Value::Integer(i) => i.map(my::Value::Int),
                 Value::Real(f) => match f {
                     Some(f) => {
-                        let floating = f.to_string().parse::<f64>().map_err(|_| {
-                            let msg = "Decimal is not a f64.";
-                            let kind = ErrorKind::conversion(msg);
+                        // let floating = f.to_string().parse::<f64>().map_err(|_| {
+                        //     let msg = "Decimal is not a f64.";
+                        //     let kind = ErrorKind::conversion(msg);
 
-                            Error::builder(kind).build()
-                        })?;
+                        //     Error::builder(kind).build()
+                        // })?;
 
-                        Some(my::Value::Double(floating))
+                        Some(my::Value::Bytes(f.to_string().as_bytes().to_vec()))
                     }
                     None => None,
                 },
@@ -63,7 +63,7 @@ pub fn conv_params<'a>(params: &[Value<'a>]) -> crate::Result<my::Params> {
                     let mut builder = Error::builder(kind);
                     builder.set_original_message(msg);
 
-                    return Err(builder.build())
+                    return Err(builder.build());
                 }
                 #[cfg(feature = "uuid-0_8")]
                 Value::Uuid(u) => u.map(|u| my::Value::Bytes(u.to_hyphenated().to_string().into_bytes())),
@@ -276,12 +276,12 @@ impl TakeRow for my::Row {
                 my::Value::Time(is_neg, days, hours, minutes, seconds, micros) => {
                     if is_neg {
                         let kind = ErrorKind::conversion("Failed to convert a negative time");
-                        return Err(Error::builder(kind).build())
+                        return Err(Error::builder(kind).build());
                     }
 
                     if days != 0 {
                         let kind = ErrorKind::conversion("Failed to read a MySQL `time` as duration");
-                        return Err(Error::builder(kind).build())
+                        return Err(Error::builder(kind).build());
                     }
 
                     let time = NaiveTime::from_hms_micro(hours.into(), minutes.into(), seconds.into(), micros);
@@ -310,7 +310,7 @@ impl TakeRow for my::Row {
                         );
 
                         let kind = ErrorKind::conversion(msg);
-                        return Err(Error::builder(kind).build())
+                        return Err(Error::builder(kind).build());
                     }
                 },
                 #[cfg(not(feature = "chrono-0_4"))]

--- a/src/connector/mysql/conversion.rs
+++ b/src/connector/mysql/conversion.rs
@@ -23,16 +23,7 @@ pub fn conv_params<'a>(params: &[Value<'a>]) -> crate::Result<my::Params> {
             let res = match pv {
                 Value::Integer(i) => i.map(my::Value::Int),
                 Value::Real(f) => match f {
-                    Some(f) => {
-                        // let floating = f.to_string().parse::<f64>().map_err(|_| {
-                        //     let msg = "Decimal is not a f64.";
-                        //     let kind = ErrorKind::conversion(msg);
-
-                        //     Error::builder(kind).build()
-                        // })?;
-
-                        Some(my::Value::Bytes(f.to_string().as_bytes().to_vec()))
-                    }
+                    Some(f) => Some(my::Value::Bytes(f.to_string().as_bytes().to_vec())),
                     None => None,
                 },
                 Value::Text(s) => s.clone().map(|s| my::Value::Bytes((&*s).as_bytes().to_vec())),

--- a/src/connector/sqlite/conversion.rs
+++ b/src/connector/sqlite/conversion.rs
@@ -118,7 +118,7 @@ impl<'a> GetRow for SqliteRow<'a> {
                             let msg = format!("Value {} not supported", n);
                             let kind = ErrorKind::conversion(msg);
 
-                            return Err(Error::builder(kind).build())
+                            return Err(Error::builder(kind).build());
                         }
                         None => Value::Integer(None),
                     },
@@ -212,7 +212,7 @@ impl<'a> ToSql for Value<'a> {
                 let mut builder = Error::builder(kind);
                 builder.set_original_message(msg);
 
-                return Err(RusqlError::ToSqlConversionFailure(Box::new(builder.build())))
+                return Err(RusqlError::ToSqlConversionFailure(Box::new(builder.build())));
             }
             #[cfg(feature = "json-1")]
             Value::Json(value) => value.as_ref().map(|value| {


### PR DESCRIPTION
Skips parse into f64, which reduces precision, and writes string directly.