### PR TITLE
To cut a dependency hell for now, we'll copy some code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ single-postgresql = ["postgresql", "json-1", "xml", "uuid-0_8", "chrono-0_4", "a
 single-sqlite = ["sqlite", "json-1", "uuid-0_8", "chrono-0_4"]
 
 postgresql = [
-  "rust_decimal/tokio-pg",
   "native-tls",
   "tokio-postgres",
   "postgres-types",
@@ -47,6 +46,7 @@ postgresql = [
   "tokio",
   "bit-vec",
   "lru-cache",
+  "byteorder",
 ]
 
 array = []
@@ -70,10 +70,11 @@ metrics = "0.12"
 num_cpus = "1.12"
 once_cell = "1.3"
 percent-encoding = "2"
-rust_decimal = {git = "https://github.com/pimeys/rust-decimal", branch = "pgbouncer-mode"}
+rust_decimal = "1.8"
 thiserror = "1.0"
 url = "2.1"
 
+byteorder = { default-features = false, optional = true, version = "1.3" }
 base64 = {version = "0.11.0", optional = true}
 chrono = {version = "0.4", optional = true}
 lru-cache = {version = "0.1", optional = true}
@@ -108,7 +109,7 @@ test-setup = {path = "test-setup"}
 tokio = {version = "0.2", features = ["rt-threaded", "macros"]}
 
 [dependencies.tiberius]
-branch = "pgbouncer-mode-hack"
+version = "0.4.12"
 features = ["rust_decimal", "sql-browser-tokio", "chrono"]
 git = "https://github.com/prisma/tiberius"
 optional = true

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -99,7 +99,8 @@ impl MysqlUrl {
         self.url.port().unwrap_or(3306)
     }
 
-    pub(crate) fn connect_timeout(&self) -> Option<Duration> {
+    /// The connection timeout.
+    pub fn connect_timeout(&self) -> Option<Duration> {
         self.query_params.connect_timeout
     }
 

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -217,7 +217,8 @@ impl PostgresUrl {
         self.query_params.pg_bouncer
     }
 
-    pub(crate) fn connect_timeout(&self) -> Option<Duration> {
+    /// The connection timeout.
+    pub fn connect_timeout(&self) -> Option<Duration> {
         self.query_params.connect_timeout
     }
 

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -1,3 +1,5 @@
+mod decimal;
+
 use crate::{
     ast::Value,
     connector::queryable::{GetRow, ToColumnNames},
@@ -7,6 +9,7 @@ use bit_vec::BitVec;
 use bytes::BytesMut;
 #[cfg(feature = "chrono-0_4")]
 use chrono::{DateTime, NaiveDateTime, Utc};
+pub(crate) use decimal::DecimalWrapper;
 use postgres_types::{FromSql, ToSql};
 use rust_decimal::{
     prelude::{FromPrimitive, ToPrimitive},
@@ -111,7 +114,11 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Integer(None),
                 },
-                PostgresType::NUMERIC => Value::Real(row.try_get(i)?),
+                PostgresType::NUMERIC => {
+                    let dw: Option<DecimalWrapper> = row.try_get(i)?;
+
+                    Value::Real(dw.map(|dw| dw.0))
+                }
                 PostgresType::FLOAT4 => match row.try_get(i)? {
                     Some(val) => {
                         let val: Decimal = Decimal::from_f32(val).expect("f32 is not a Decimal");
@@ -275,9 +282,9 @@ impl GetRow for PostgresRow {
                 #[cfg(feature = "array")]
                 PostgresType::NUMERIC_ARRAY => match row.try_get(i)? {
                     Some(val) => {
-                        let val: Vec<Decimal> = val;
+                        let val: Vec<DecimalWrapper> = val;
 
-                        let decimals = val.into_iter().map(|x| Value::real(x.to_string().parse().unwrap()));
+                        let decimals = val.into_iter().map(|x| Value::real(x.0.to_string().parse().unwrap()));
 
                         Value::array(decimals)
                     }
@@ -535,8 +542,10 @@ impl<'a> ToSql for Value<'a> {
                 let i = i64::from_le_bytes(i64_bytes);
                 i.to_sql(ty, out)
             }),
-            (Value::Real(decimal), &PostgresType::NUMERIC) => decimal.map(|decimal| decimal.to_sql(ty, out)),
-            (Value::Real(float), _) => float.map(|float| float.to_sql(ty, out)),
+            (Value::Real(decimal), &PostgresType::NUMERIC) => {
+                decimal.map(|decimal| DecimalWrapper(decimal).to_sql(ty, out))
+            }
+            (Value::Real(float), _) => float.map(|float| DecimalWrapper(float).to_sql(ty, out)),
             #[cfg(feature = "uuid-0_8")]
             (Value::Text(string), &PostgresType::UUID) => string.as_ref().map(|string| {
                 let parsed_uuid: Uuid = string.parse()?;
@@ -648,7 +657,7 @@ fn string_to_bits(s: &str) -> crate::Result<BitVec> {
                 let msg = "Unexpected character for bits input. Expected only 1 and 0.";
                 let kind = ErrorKind::conversion(msg);
 
-                return Err(Error::builder(kind).build())
+                return Err(Error::builder(kind).build());
             }
         }
     }

--- a/src/connector/postgres/conversion/decimal.rs
+++ b/src/connector/postgres/conversion/decimal.rs
@@ -1,0 +1,293 @@
+//! We implement the postgres conversions here to fix a disastrous dependency hell.
+
+use byteorder::{BigEndian, ReadBytesExt};
+use bytes::{BufMut, BytesMut};
+use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
+use rust_decimal::{prelude::Zero, Decimal};
+use std::convert::TryInto;
+use std::{error, fmt, io::Cursor};
+
+const MAX_PRECISION: u32 = 28;
+
+#[derive(Debug, Clone)]
+pub struct DecimalWrapper(pub Decimal);
+
+#[derive(Debug, Clone)]
+pub struct InvalidDecimal {
+    inner: Option<String>,
+}
+
+impl fmt::Display for InvalidDecimal {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(ref msg) = self.inner {
+            fmt.write_fmt(format_args!("Invalid Decimal: {}", msg))
+        } else {
+            fmt.write_str("Invalid Decimal")
+        }
+    }
+}
+
+impl error::Error for InvalidDecimal {}
+
+struct PostgresDecimal<D> {
+    neg: bool,
+    weight: i16,
+    scale: u16,
+    digits: D,
+}
+
+fn from_postgres<D: ExactSizeIterator<Item = u16>>(dec: PostgresDecimal<D>) -> Result<Decimal, InvalidDecimal> {
+    let PostgresDecimal {
+        neg,
+        scale,
+        digits,
+        weight,
+    } = dec;
+
+    let mut digits = digits.into_iter().collect::<Vec<_>>();
+
+    let fractionals_part_count = digits.len() as i32 + (-weight as i32) - 1;
+    let integers_part_count = weight as i32 + 1;
+
+    let mut result = Decimal::zero();
+
+    // adding integer part
+    if integers_part_count > 0 {
+        let (start_integers, last) = if integers_part_count > digits.len() as i32 {
+            (integers_part_count - digits.len() as i32, digits.len() as i32)
+        } else {
+            (0, integers_part_count)
+        };
+
+        let integers: Vec<_> = digits.drain(..last as usize).collect();
+
+        for digit in integers {
+            result *= Decimal::from_i128_with_scale(10i128.pow(4), 0);
+            result += Decimal::new(digit as i64, 0);
+        }
+
+        result *= Decimal::from_i128_with_scale(10i128.pow(4 * start_integers as u32), 0);
+    }
+
+    // adding fractional part
+    if fractionals_part_count > 0 {
+        let dec: Vec<_> = digits.into_iter().collect();
+        let start_fractionals = if weight < 0 { (-weight as u32) - 1 } else { 0 };
+
+        for (i, digit) in dec.into_iter().enumerate() {
+            let fract_pow = 4 * (i as u32 + 1 + start_fractionals);
+
+            if fract_pow <= MAX_PRECISION {
+                result += Decimal::new(digit as i64, 0) / Decimal::from_i128_with_scale(10i128.pow(fract_pow), 0);
+            } else if fract_pow == MAX_PRECISION + 4 {
+                // rounding last digit
+                if digit >= 5000 {
+                    result += Decimal::new(1 as i64, 0) / Decimal::from_i128_with_scale(10i128.pow(MAX_PRECISION), 0);
+                }
+            }
+        }
+    }
+
+    result.set_sign_negative(neg);
+
+    // Rescale to the postgres value, automatically rounding as needed.
+    result.rescale(scale as u32);
+
+    Ok(result)
+}
+
+fn to_postgres(decimal: Decimal) -> PostgresDecimal<Vec<i16>> {
+    if decimal.is_zero() {
+        return PostgresDecimal {
+            neg: false,
+            weight: 0,
+            scale: 0,
+            digits: vec![0],
+        };
+    }
+
+    let scale = decimal.scale() as u16;
+
+    // A serialized version of the decimal number. The resulting byte array
+    // will have the following representation:
+    //
+    // Bytes 1-4: flags
+    // Bytes 5-8: lo portion of m
+    // Bytes 9-12: mid portion of m
+    // Bytes 13-16: high portion of m
+    let mut mantissa = u128::from_le_bytes(decimal.serialize());
+
+    // chop off the flags
+    mantissa >>= 32;
+
+    // If our scale is not a multiple of 4, we need to go to the next
+    // multiple.
+    let groups_diff = scale % 4;
+    if groups_diff > 0 {
+        let remainder = 4 - groups_diff as u32;
+        let power = 10u32.pow(remainder as u32) as u128;
+
+        mantissa = mantissa * power;
+    }
+
+    // Array to store max mantissa of Decimal in Postgres decimal format.
+    let mut digits = Vec::with_capacity(8);
+
+    // Convert to base-10000.
+    while mantissa != 0 {
+        digits.push((mantissa % 10_000) as i16);
+        mantissa /= 10_000;
+    }
+
+    // Change the endianness.
+    digits.reverse();
+
+    // Weight is number of digits on the left side of the decimal.
+    let digits_after_decimal = (scale + 3) as u16 / 4;
+    let weight = digits.len() as i16 - digits_after_decimal as i16 - 1;
+
+    // Remove non-significant zeroes.
+    while let Some(&0) = digits.last() {
+        digits.pop();
+    }
+
+    PostgresDecimal {
+        neg: decimal.is_sign_negative(),
+        scale,
+        weight,
+        digits,
+    }
+}
+
+impl<'a> FromSql<'a> for DecimalWrapper {
+    // Decimals are represented as follows:
+    // Header:
+    //  u16 numGroups
+    //  i16 weightFirstGroup (10000^weight)
+    //  u16 sign (0x0000 = positive, 0x4000 = negative, 0xC000 = NaN)
+    //  i16 dscale. Number of digits (in base 10) to print after decimal separator
+    //
+    //  Pseudo code :
+    //  const Decimals [
+    //          0.0000000000000000000000000001,
+    //          0.000000000000000000000001,
+    //          0.00000000000000000001,
+    //          0.0000000000000001,
+    //          0.000000000001,
+    //          0.00000001,
+    //          0.0001,
+    //          1,
+    //          10000,
+    //          100000000,
+    //          1000000000000,
+    //          10000000000000000,
+    //          100000000000000000000,
+    //          1000000000000000000000000,
+    //          10000000000000000000000000000
+    //  ]
+    //  overflow = false
+    //  result = 0
+    //  for i = 0, weight = weightFirstGroup + 7; i < numGroups; i++, weight--
+    //    group = read.u16
+    //    if weight < 0 or weight > MaxNum
+    //       overflow = true
+    //    else
+    //       result += Decimals[weight] * group
+    //  sign == 0x4000 ? -result : result
+
+    // So if we were to take the number: 3950.123456
+    //
+    //  Stored on Disk:
+    //    00 03 00 00 00 00 00 06 0F 6E 04 D2 15 E0
+    //
+    //  Number of groups: 00 03
+    //  Weight of first group: 00 00
+    //  Sign: 00 00
+    //  DScale: 00 06
+    //
+    // 0F 6E = 3950
+    //   result = result + 3950 * 1;
+    // 04 D2 = 1234
+    //   result = result + 1234 * 0.0001;
+    // 15 E0 = 5600
+    //   result = result + 5600 * 0.00000001;
+    //
+
+    fn from_sql(_: &Type, raw: &[u8]) -> Result<DecimalWrapper, Box<dyn error::Error + 'static + Sync + Send>> {
+        let mut raw = Cursor::new(raw);
+        let num_groups = raw.read_u16::<BigEndian>()?;
+        let weight = raw.read_i16::<BigEndian>()?; // 10000^weight
+                                                   // Sign: 0x0000 = positive, 0x4000 = negative, 0xC000 = NaN
+        let sign = raw.read_u16::<BigEndian>()?;
+
+        // Number of digits (in base 10) to print after decimal separator
+        let scale = raw.read_u16::<BigEndian>()?;
+
+        // Read all of the groups
+        let mut groups = Vec::new();
+        for _ in 0..num_groups as usize {
+            groups.push(raw.read_u16::<BigEndian>()?);
+        }
+
+        let dec = from_postgres(PostgresDecimal {
+            neg: sign == 0x4000,
+            weight,
+            scale,
+            digits: groups.into_iter(),
+        })
+        .map_err(Box::new)?;
+
+        Ok(DecimalWrapper(dec))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        match ty {
+            &Type::NUMERIC => true,
+            _ => false,
+        }
+    }
+}
+
+impl ToSql for DecimalWrapper {
+    fn to_sql(&self, _: &Type, out: &mut BytesMut) -> Result<IsNull, Box<dyn error::Error + 'static + Sync + Send>> {
+        let PostgresDecimal {
+            neg,
+            weight,
+            scale,
+            digits,
+        } = to_postgres(self.0);
+
+        let num_digits = digits.len();
+
+        // Reserve bytes
+        out.reserve(8 + num_digits * 2);
+
+        // Number of groups
+        out.put_u16(num_digits.try_into().unwrap());
+
+        // Weight of first group
+        out.put_i16(weight);
+
+        // Sign
+        out.put_u16(if neg { 0x4000 } else { 0x0000 });
+
+        // DScale
+        out.put_u16(scale);
+
+        // Now process the number
+        for digit in digits[0..num_digits].iter() {
+            out.put_i16(*digit);
+        }
+
+        Ok(IsNull::No)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        match ty {
+            &Type::NUMERIC => true,
+            _ => false,
+        }
+    }
+
+    to_sql_checked!();
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -184,6 +184,13 @@ impl From<Error> for ErrorKind {
     }
 }
 
+impl From<rust_decimal::Error> for Error {
+    fn from(e: rust_decimal::Error) -> Self {
+        let kind = ErrorKind::conversion(format!("{}", e));
+        Self::builder(kind).build()
+    }
+}
+
 #[cfg(feature = "json-1")]
 impl From<serde_json::Error> for Error {
     fn from(_: serde_json::Error) -> Self {

--- a/src/tests/test_api/mysql.rs
+++ b/src/tests/test_api/mysql.rs
@@ -53,7 +53,7 @@ impl<'a> TestApi for MySql<'a> {
     fn render_create_table(&mut self, table_name: &str, columns: &str) -> (String, String) {
         let create = format!(
             r##"
-            CREATE TEMPORARY TABLE `{}` ({}) ENGINE=InnoDB DEFAULT CHARSET=latin1
+            CREATE TEMPORARY TABLE `{}` ({}) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
             "##,
             table_name, columns,
         );

--- a/src/tests/types/postgres.rs
+++ b/src/tests/types/postgres.rs
@@ -1,4 +1,5 @@
 use crate::tests::test_api::*;
+use rust_decimal::Decimal;
 use std::str::FromStr;
 
 test_type!(boolean(
@@ -100,7 +101,165 @@ test_type!(decimal(
     postgres,
     "decimal(10,2)",
     Value::Real(None),
-    Value::real(rust_decimal::Decimal::new(314, 2))
+    Value::real(Decimal::new(314, 2))
+));
+
+test_type!(decimal_10_2(
+    postgres,
+    "decimal(10, 2)",
+    (
+        Value::real(Decimal::from_str("3950.123456")?),
+        Value::real(Decimal::from_str("3950.12")?)
+    )
+));
+
+test_type!(decimal_35_6(
+    postgres,
+    "decimal(35, 6)",
+    (
+        Value::real(Decimal::from_str("3950")?),
+        Value::real(Decimal::from_str("3950.000000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("3950.123456")?),
+        Value::real(Decimal::from_str("3950.123456")?)
+    ),
+    (
+        Value::real(Decimal::from_str("0.1")?),
+        Value::real(Decimal::from_str("0.100000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("0.01")?),
+        Value::real(Decimal::from_str("0.010000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("0.001")?),
+        Value::real(Decimal::from_str("0.001000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("0.0001")?),
+        Value::real(Decimal::from_str("0.000100")?)
+    ),
+    (
+        Value::real(Decimal::from_str("0.00001")?),
+        Value::real(Decimal::from_str("0.000010")?)
+    ),
+    (
+        Value::real(Decimal::from_str("0.000001")?),
+        Value::real(Decimal::from_str("0.000001")?)
+    ),
+    (
+        Value::real(Decimal::from_str("1")?),
+        Value::real(Decimal::from_str("1.000000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("-100")?),
+        Value::real(Decimal::from_str("-100.000000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("-123.456")?),
+        Value::real(Decimal::from_str("-123.456000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("119996.25")?),
+        Value::real(Decimal::from_str("119996.250000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("1000000")?),
+        Value::real(Decimal::from_str("1000000.000000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("9999999.99999")?),
+        Value::real(Decimal::from_str("9999999.999990")?)
+    ),
+    (
+        Value::real(Decimal::from_str("12340.56789")?),
+        Value::real(Decimal::from_str("12340.567890")?)
+    ),
+    (
+        Value::real(Decimal::from_str("18446744073709551615")?),
+        Value::real(Decimal::from_str("18446744073709551615.000000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("-18446744073709551615")?),
+        Value::real(Decimal::from_str("-18446744073709551615.000000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("0.10001")?),
+        Value::real(Decimal::from_str("0.100010")?)
+    ),
+    (
+        Value::real(Decimal::from_str("0.12345")?),
+        Value::real(Decimal::from_str("0.123450")?)
+    ),
+));
+
+test_type!(decimal_35_2(
+    postgres,
+    "decimal(35, 2)",
+    (
+        Value::real(Decimal::from_str("3950.123456")?),
+        Value::real(Decimal::from_str("3950.12")?)
+    ),
+    (
+        Value::real(Decimal::from_str("3950.1256")?),
+        Value::real(Decimal::from_str("3950.13")?)
+    ),
+));
+
+test_type!(decimal_4_0(
+    postgres,
+    "decimal(4, 0)",
+    Value::real(Decimal::from_str("3950")?)
+));
+
+test_type!(decimal_65_30(
+    postgres,
+    "decimal(65, 30)",
+    (
+        Value::real(Decimal::from_str("1.2")?),
+        Value::real(Decimal::from_str("1.2000000000000000000000000000")?)
+    ),
+    (
+        Value::real(Decimal::from_str("3.141592653589793238462643383279")?),
+        Value::real(Decimal::from_str("3.1415926535897932384626433833")?)
+    )
+));
+
+test_type!(decimal_65_34(
+    postgres,
+    "decimal(65, 34)",
+    (
+        Value::real(Decimal::from_str("3.1415926535897932384626433832795028")?),
+        Value::real(Decimal::from_str("3.1415926535897932384626433833")?)
+    ),
+    (
+        Value::real(Decimal::from_str("1.234567890123456789012345678950000")?),
+        Value::real(Decimal::from_str("1.2345678901234567890123456790")?)
+    ),
+    (
+        Value::real(Decimal::from_str("1.234567890123456789012345678949999")?),
+        Value::real(Decimal::from_str("1.2345678901234567890123456789")?)
+    ),
+));
+
+test_type!(decimal_35_0(
+    postgres,
+    "decimal(35, 0)",
+    Value::real(Decimal::from_str("79228162514264337593543950335")?),
+));
+
+test_type!(decimal_35_1(
+    postgres,
+    "decimal(35, 1)",
+    (
+        Value::real(Decimal::from_str("79228162514264337593543950335")?),
+        Value::real(Decimal::from_str("79228162514264337593543950335.0")?)
+    ),
+    (
+        Value::real(Decimal::from_str("4951760157141521099596496896")?),
+        Value::real(Decimal::from_str("4951760157141521099596496896.0")?)
+    )
 ));
 
 #[cfg(feature = "array")]
@@ -108,10 +267,7 @@ test_type!(decimal_array(
     postgres,
     "decimal(10,2)[]",
     Value::Array(None),
-    Value::array(vec![
-        rust_decimal::Decimal::new(314, 2),
-        rust_decimal::Decimal::new(512, 2)
-    ])
+    Value::array(vec![Decimal::new(314, 2), Decimal::new(512, 2)])
 ));
 
 test_type!(float4(


### PR DESCRIPTION
THIS IS WHAT IT ALL MEANS PEOPLE!

Copied the `ToSql`/`FromSql` code from rust-decimal to cut a bad dependency hell and get many of our deps back to crates.io. Some of the code is cleaned using the knowledge from SQLx, but it's still quite a lot :(