### PR TITLE
Feature flag cleanup

### DIFF
--- a/.buildkite/docker.sh
+++ b/.buildkite/docker.sh
@@ -27,11 +27,12 @@ docker run --name test-mssql --network test-net \
     -d mcr.microsoft.com/mssql/server:2019-latest
 
 docker run -w /build --network test-net -v $BUILDKITE_BUILD_CHECKOUT_PATH:/build \
+    -e RUSTFLAGS="-D warnings" \
     -e TEST_MYSQL=mysql://prisma:prisma@test-mysql:3306/prisma \
     -e TEST_MYSQL8=mysql://prisma:prisma@test-mysql-8:3306/prisma \
     -e TEST_PSQL=postgres://prisma:prisma@test-postgres:5432/prisma \
     -e TEST_MSSQL="jdbc:sqlserver://test-mssql:1433;user=SA;password=$MSSQL_SA_PASSWORD;trustServerCertificate=true" \
-    prismagraphql/build:test cargo test --features full,json-1,xml,uuid-0_8,chrono-0_4,tracing-log,serde-support
+    prismagraphql/build:test $1
 
 exit_code=$?
 

--- a/.buildkite/pipeline.sh
+++ b/.buildkite/pipeline.sh
@@ -4,8 +4,32 @@ set -e
 
 pipeline=$(printf "
 steps:
-    - label: \":rust: Cargo test\"
-      command: ./.buildkite/docker.sh
+    - label: \":rust: All features\"
+      command: ./.buildkite/docker.sh \"cargo test --all-features\"
+
+    - label: \":sqlite: Sqlite minimal\"
+      command: ./.buildkite/docker.sh \"cargo test --lib --no-default-features --features=sqlite\"
+
+    - label: \":sqlite: Sqlite full\"
+      command: ./.buildkite/docker.sh \"cargo test --lib --no-default-features --features=sqlite,chrono,json,uuid,pooled,serde-support\"
+
+    - label: \":postgres: PostgreSQL minimal\"
+      command: ./.buildkite/docker.sh \"cargo test --lib --no-default-features --features=postgresql\"
+
+    - label: \":postgres: PostgreSQL full\"
+      command: ./.buildkite/docker.sh \"cargo test --lib --no-default-features --features=postgresql,chrono,json,uuid,pooled,serde-support\"
+
+    - label: \":mysql: MySQL minimal\"
+      command: ./.buildkite/docker.sh \"cargo test --lib --no-default-features --features=mysql\"
+
+    - label: \":mysql: MySQL full\"
+      command: ./.buildkite/docker.sh \"cargo test --lib --no-default-features --features=mysql,chrono,json,uuid,pooled,serde-support\"
+
+    - label: \":windows: SQL Server minimal\"
+      command: ./.buildkite/docker.sh \"cargo test --lib --no-default-features --features=mssql\"
+
+    - label: \":windows: SQL Server full\"
+      command: ./.buildkite/docker.sh \"cargo test --lib --no-default-features --features=mssql,chrono,json,uuid,pooled,serde-support\"
 
     - wait
 

--- a/.buildkite/publish_rustdoc.sh
+++ b/.buildkite/publish_rustdoc.sh
@@ -3,7 +3,7 @@
 set -e
 shopt -s globstar
 
-docker run -w /build -v $(pwd):/build prismagraphql/build:test cargo rustdoc --features full,json-1,uuid-0_8,chrono-0_4,tracing-log,serde-support
+docker run -w /build -v $(pwd):/build prismagraphql/build:test cargo rustdoc --all-features
 
 rm -rf deploy_docs
 git clone --branch gh-pages "git@github.com:prisma/quaint.git" deploy_docs > /dev/null 2>&1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,22 +19,20 @@ repository = "https://github.com/prisma/quaint/"
 version = "0.2.0-alpha.13"
 
 [package.metadata.docs.rs]
-features = ["full", "serde-support", "json-1", "uuid-0_8", "chrono-0_4"]
+features = [
+  "chrono",
+  "json",
+  "mssql",
+  "mysql",
+  "pooled",
+  "postgresql",
+  "serde-support",
+  "sqlite",
+  "uuid",
+]
 
 [features]
 default = []
-
-full = ["pooled", "sqlite", "json-1", "postgresql", "uuid-0_8", "chrono-0_4", "mysql", "mssql"]
-full-mssql = ["pooled", "mssql", "tokio/time"]
-full-mysql = ["pooled", "mysql", "json-1", "uuid-0_8", "chrono-0_4"]
-full-postgresql = ["pooled", "postgresql", "json-1", "uuid-0_8", "chrono-0_4"]
-full-sqlite = ["pooled", "sqlite", "json-1", "uuid-0_8", "chrono-0_4"]
-
-single = ["sqlite", "json-1", "postgresql", "uuid-0_8", "chrono-0_4", "mysql", "mssql"]
-single-mssql = ["mssql", "tokio/time"]
-single-mysql = ["mysql", "json-1", "uuid-0_8", "chrono-0_4"]
-single-postgresql = ["postgresql", "json-1", "uuid-0_8", "chrono-0_4"]
-single-sqlite = ["sqlite", "json-1", "uuid-0_8", "chrono-0_4"]
 
 postgresql = [
   "native-tls",
@@ -48,19 +46,16 @@ postgresql = [
   "byteorder",
 ]
 
-chrono-0_4 = ["chrono"]
-json-1 = ["serde_json", "base64"]
-mssql = ["tiberius", "uuid-0_8", "chrono-0_4", "tokio-util"]
-mysql = ["mysql_async", "tokio"]
+json = ["serde_json", "base64"]
+mssql = ["tiberius", "uuid", "chrono", "tokio-util", "tokio/time", "tokio/net", "either"]
+mysql = ["mysql_async", "tokio/time"]
 pooled = ["mobc"]
 serde-support = ["serde", "chrono/serde"]
 sqlite = ["rusqlite", "libsqlite3-sys", "tokio/sync"]
 tracing-log = ["tracing", "tracing-core"]
-uuid-0_8 = ["uuid"]
 
 [dependencies]
 async-trait = "0.1"
-either = "1.6"
 futures = "0.3"
 hex = "0.4"
 metrics = "0.12"
@@ -71,40 +66,37 @@ rust_decimal = "1.8"
 thiserror = "1.0"
 url = "2.1"
 
+either = { version = "1.6", optional = true }
 byteorder = { default-features = false, optional = true, version = "1.3" }
-base64 = {version = "0.11.0", optional = true}
-chrono = {version = "0.4", optional = true}
-lru-cache = {version = "0.1", optional = true}
-serde_json = {version = "1.0.48", optional = true}
-uuid = {version = "0.8", optional = true}
-
-libsqlite3-sys = {version = "0.18", default-features = false, features = ["bundled"], optional = true}
-rusqlite = {version = "0.23", features = ["chrono", "bundled"], optional = true}
-
-native-tls = {version = "0.2", optional = true}
-
-mysql_async = {version = "0.24.2", optional = true}
-
-log = {version = "0.4", features = ["release_max_level_trace"]}
-tracing = {version = "0.1", optional = true}
-tracing-core = {version = "0.1", optional = true}
-
-bit-vec = {version = "0.6.1", optional = true}
-bytes = {version = "0.5", optional = true}
-mobc = {version = "0.5.7", optional = true}
-serde = {version = "1.0", optional = true}
-tokio = {version = "0.2", features = ["rt-threaded", "macros", "sync"], optional = true}
-tokio-util = {version = "0.3", features = ["compat"], optional = true}
+base64 = { version = "0.11.0", optional = true }
+chrono = { version = "0.4", optional = true }
+lru-cache = { version = "0.1", optional = true }
+serde_json = { version = "1.0.48", optional = true }
+rusqlite = { version = "0.23", features = ["chrono", "bundled"], optional = true }
+native-tls = { version = "0.2", optional = true }
+mysql_async = { version = "0.24.2", optional = true }
+log = { version = "0.4", features = ["release_max_level_trace"] }
+tracing = { version = "0.1", optional = true }
+tracing-core = { version = "0.1", optional = true }
+bit-vec = { version = "0.6.1", optional = true }
+bytes = { version = "0.5", optional = true }
+mobc = { version = "0.5.7", optional = true }
+serde = { version = "1.0", optional = true }
 connection-string = "0.1.10"
 
 [dev-dependencies]
 indoc = "0.3"
 names = "0.11"
 paste = "1.0"
-serde = {version = "1.0", features = ["derive"]}
-test-macros = {path = "test-macros"}
-test-setup = {path = "test-setup"}
-tokio = {version = "0.2", features = ["rt-threaded", "macros"]}
+serde = { version = "1.0", features = ["derive"] }
+test-macros = { path = "test-macros" }
+test-setup = { path = "test-setup" }
+uuid = { version = "0.8", features = ["v4"] }
+tokio = { version = "0.2", features = ["rt-threaded", "macros", "io-driver", "time"] }
+
+[dependencies.uuid]
+version = "0.8"
+optional = true
 
 [dependencies.tiberius]
 version = "0.4.13"
@@ -126,4 +118,20 @@ optional = true
 [dependencies.postgres-native-tls]
 branch = "pgbouncer-mode"
 git = "https://github.com/pimeys/rust-postgres"
+optional = true
+
+[dependencies.libsqlite3-sys]
+version = "0.18"
+default-features = false
+features = ["bundled"]
+optional = true
+
+[dependencies.tokio]
+version = "0.2"
+features = ["rt-threaded", "macros", "sync"]
+optional = true
+
+[dependencies.tokio-util]
+version = "0.3"
+features = ["compat"]
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ repository = "https://github.com/prisma/quaint/"
 version = "0.2.0-alpha.13"
 
 [package.metadata.docs.rs]
-features = ["full", "serde-support", "json-1", "uuid-0_8", "chrono-0_4", "array"]
+features = ["full", "serde-support", "json-1", "uuid-0_8", "chrono-0_4"]
 
 [features]
 default = []
 
 full = ["pooled", "sqlite", "json-1", "postgresql", "uuid-0_8", "chrono-0_4", "mysql", "mssql"]
-full-mssql = ["pooled", "mssql", "xml", "tokio/time"]
+full-mssql = ["pooled", "mssql", "tokio/time"]
 full-mysql = ["pooled", "mysql", "json-1", "uuid-0_8", "chrono-0_4"]
-full-postgresql = ["pooled", "postgresql", "json-1", "xml", "uuid-0_8", "chrono-0_4", "array"]
+full-postgresql = ["pooled", "postgresql", "json-1", "uuid-0_8", "chrono-0_4"]
 full-sqlite = ["pooled", "sqlite", "json-1", "uuid-0_8", "chrono-0_4"]
 
-single = ["sqlite", "json-1", "xml", "postgresql", "uuid-0_8", "chrono-0_4", "mysql", "mssql"]
-single-mssql = ["mssql", "xml", "tokio/time"]
+single = ["sqlite", "json-1", "postgresql", "uuid-0_8", "chrono-0_4", "mysql", "mssql"]
+single-mssql = ["mssql", "tokio/time"]
 single-mysql = ["mysql", "json-1", "uuid-0_8", "chrono-0_4"]
-single-postgresql = ["postgresql", "json-1", "xml", "uuid-0_8", "chrono-0_4", "array"]
+single-postgresql = ["postgresql", "json-1", "uuid-0_8", "chrono-0_4"]
 single-sqlite = ["sqlite", "json-1", "uuid-0_8", "chrono-0_4"]
 
 postgresql = [
@@ -41,7 +41,6 @@ postgresql = [
   "tokio-postgres",
   "postgres-types",
   "postgres-native-tls",
-  "array",
   "bytes",
   "tokio",
   "bit-vec",
@@ -49,7 +48,6 @@ postgresql = [
   "byteorder",
 ]
 
-array = []
 chrono-0_4 = ["chrono"]
 json-1 = ["serde_json", "base64"]
 mssql = ["tiberius", "uuid-0_8", "chrono-0_4", "tokio-util"]
@@ -59,7 +57,6 @@ serde-support = ["serde", "chrono/serde"]
 sqlite = ["rusqlite", "libsqlite3-sys", "tokio/sync"]
 tracing-log = ["tracing", "tracing-core"]
 uuid-0_8 = ["uuid"]
-xml = []
 
 [dependencies]
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ Quaint is an abstraction over certain SQL databases. It provides:
 
 ### Feature flags
 
-- `full`: All connectors and a pooled `Quaint` manager
-- `full-postgresql`: Pooled support for PostgreSQL
-- `full-mysql`: Pooled support for MySQL
-- `full-sqlite`: Pooled support for SQLite
-- `full-mssql`: Pooled support for Microsoft SQL Server
-- `single`: All connectors, but no pooling
-- `single-postgresql`: Single connection support for PostgreSQL
-- `single-mysql`: Single connection support for MySQL
-- `single-sqlite`: Single connection support for SQLite
-- `single-mssql`: Single connection support for Microsoft SQL Server
+- `mysql`: Support for MySQL databases.
+- `postgresql`: Support for PostgreSQL databases.
+- `sqlite`: Support for SQLite databases.
+- `mssql`: Support for Microsoft SQL Server databases.
+- `pooled`: A connection pool in `pooled::Quaint`.
+- `json`: JSON type support with `serde_json` crate.
+- `uuid`: UUID type support with `uuid` crate.
+- `chrono`: DateTime type support with `chrono` crate.
+- `serde-support`: Deserialize support from result set with `serde` crate.
+- `tracing-log`: Logging with `tracing` crate.
 
 ### Goals:
 

--- a/src/ast/conditions.rs
+++ b/src/ast/conditions.rs
@@ -20,6 +20,7 @@ pub enum ConditionTree<'a> {
 impl<'a> ConditionTree<'a> {
     // Finds all possible comparisons between a tuple and a select. If returning
     // a vector of CTEs, they should be handled by the calling party.
+    #[cfg(feature = "mssql")]
     pub(crate) fn convert_tuple_selects_to_ctes(self, level: &mut usize) -> (Self, Vec<CommonTableExpression<'a>>) {
         fn convert_many<'a>(
             exprs: Vec<Expression<'a>>,

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -49,7 +49,6 @@ impl<'a> Expression<'a> {
         }
     }
 
-    #[cfg(feature = "xml")]
     pub(crate) fn is_xml_value(&self) -> bool {
         self.kind.is_xml_value()
     }
@@ -170,7 +169,6 @@ pub enum ExpressionKind<'a> {
 }
 
 impl<'a> ExpressionKind<'a> {
-    #[cfg(feature = "xml")]
     pub(crate) fn is_xml_value(&self) -> bool {
         match self {
             Self::Parameterized(Value::Xml(_)) => true,

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -1,5 +1,4 @@
 use crate::ast::*;
-use either::Either;
 use query::SelectQuery;
 use std::borrow::Cow;
 
@@ -22,6 +21,7 @@ impl<'a> Expression<'a> {
         self.alias.as_ref().map(|s| s.as_ref())
     }
 
+    #[allow(dead_code)]
     pub(crate) fn row(row: Row<'a>) -> Self {
         Self {
             kind: ExpressionKind::Row(row),
@@ -33,6 +33,7 @@ impl<'a> Expression<'a> {
         Self::selection(SelectQuery::Union(Box::new(union)))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn selection(selection: SelectQuery<'a>) -> Self {
         Self {
             kind: ExpressionKind::Selection(selection),
@@ -40,8 +41,9 @@ impl<'a> Expression<'a> {
         }
     }
 
-    #[cfg(feature = "json-1")]
-    pub(crate) fn is_json_value(&self) -> bool {
+    #[cfg(feature = "json")]
+    #[allow(dead_code)]
+    pub fn is_json_value(&self) -> bool {
         match &self.kind {
             ExpressionKind::Parameterized(Value::Json(_)) => true,
             ExpressionKind::Value(expr) => expr.is_json_value(),
@@ -49,18 +51,22 @@ impl<'a> Expression<'a> {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_xml_value(&self) -> bool {
         self.kind.is_xml_value()
     }
 
-    pub(crate) fn is_asterisk(&self) -> bool {
+    #[allow(dead_code)]
+    pub fn is_asterisk(&self) -> bool {
         matches!(self.kind, ExpressionKind::Asterisk(_))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_row(&self) -> bool {
         matches!(self.kind, ExpressionKind::Row(_))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn into_row(self) -> Option<Row<'a>> {
         match self.kind {
             ExpressionKind::Row(row) => Some(row),
@@ -68,6 +74,7 @@ impl<'a> Expression<'a> {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn into_selection(self) -> Option<SelectQuery<'a>> {
         match self.kind {
             ExpressionKind::Selection(selection) => Some(selection),
@@ -75,6 +82,7 @@ impl<'a> Expression<'a> {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn into_column(self) -> Option<Column<'a>> {
         match self.kind {
             ExpressionKind::Column(column) => Some(*column),
@@ -82,16 +90,19 @@ impl<'a> Expression<'a> {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_selection(&self) -> bool {
         matches!(self.kind, ExpressionKind::Selection(_))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn is_column(&self) -> bool {
         matches!(self.kind, ExpressionKind::Column(_))
     }
 
     /// Finds all comparisons between a tuple and a selection. If returning some
     /// CTEs, they should be handled in the calling layer.
+    #[cfg(feature = "mssql")]
     pub(crate) fn convert_tuple_selects_to_ctes(self, level: &mut usize) -> (Self, Vec<CommonTableExpression<'a>>) {
         match self.kind {
             ExpressionKind::Selection(s) => {
@@ -106,7 +117,7 @@ impl<'a> Expression<'a> {
             }
             ExpressionKind::Compare(compare) => match compare.convert_tuple_select_to_cte(level) {
                 // No conversion
-                Either::Left(compare) => {
+                either::Either::Left(compare) => {
                     let expr = Expression {
                         kind: ExpressionKind::Compare(compare),
                         alias: self.alias,
@@ -115,7 +126,7 @@ impl<'a> Expression<'a> {
                     (expr, Vec::new())
                 }
                 // Conversion happened
-                Either::Right((comp, ctes)) => {
+                either::Either::Right((comp, ctes)) => {
                     let expr = Expression {
                         kind: ExpressionKind::Compare(comp),
                         alias: self.alias,

--- a/src/ast/query.rs
+++ b/src/ast/query.rs
@@ -1,7 +1,6 @@
 use crate::ast::{Delete, Insert, Merge, Select, Union, Update};
 use std::borrow::Cow;
 
-use super::CommonTableExpression;
 use super::IntoCommonTableExpression;
 
 /// A database query
@@ -63,7 +62,11 @@ impl<'a> SelectQuery<'a> {
         }
     }
 
-    pub(crate) fn convert_tuple_selects_to_ctes(self, level: &mut usize) -> (Self, Vec<CommonTableExpression<'a>>) {
+    #[cfg(feature = "mssql")]
+    pub(crate) fn convert_tuple_selects_to_ctes(
+        self,
+        level: &mut usize,
+    ) -> (Self, Vec<super::CommonTableExpression<'a>>) {
         match self {
             Self::Select(select) => match select.convert_tuple_selects_to_ctes(false, level) {
                 either::Either::Left(select) => (Self::Select(Box::new(select)), Vec::new()),

--- a/src/ast/row.rs
+++ b/src/ast/row.rs
@@ -1,4 +1,4 @@
-use crate::ast::{Column, Comparable, Compare, Expression};
+use crate::ast::{Comparable, Compare, Expression};
 use std::borrow::Cow;
 
 /// A collection of values surrounded by parentheses.
@@ -37,11 +37,13 @@ impl<'a> Row<'a> {
         self.values.len()
     }
 
+    #[cfg(feature = "mssql")]
     pub(crate) fn is_only_columns(&self) -> bool {
         self.values.iter().all(|v| v.is_column())
     }
 
-    pub(crate) fn into_columns(self) -> Vec<Column<'a>> {
+    #[cfg(feature = "mssql")]
+    pub(crate) fn into_columns(self) -> Vec<crate::ast::Column<'a>> {
         let mut columns = Vec::with_capacity(self.len());
 
         for expr in self.values.into_iter() {

--- a/src/ast/select.rs
+++ b/src/ast/select.rs
@@ -617,6 +617,7 @@ impl<'a> Select<'a> {
     /// - Not comparing a tuple (e.g. `x IN (SELECT ...)`)
     /// - Not using a `IN` or `NOT IN` operation
     /// - Imbalanced number of variables (e.g. `(x, y, z) IN (SELECT a, b ...)`)
+    #[cfg(feature = "mssql")]
     pub(crate) fn convert_tuple_selects_to_ctes(
         mut self,
         top_level: bool,

--- a/src/ast/union.rs
+++ b/src/ast/union.rs
@@ -117,6 +117,7 @@ impl<'a> Union<'a> {
     /// Finds all comparisons between tuples and selects in the queries and
     /// converts them to common table expressions for making the query
     /// compatible with databases not supporting tuples.
+    #[cfg(feature = "mssql")]
     pub(crate) fn convert_tuple_selects_into_ctes(
         mut self,
         top_level: bool,

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -59,13 +59,11 @@ pub enum Value<'a> {
     Boolean(Option<bool>),
     /// A single character.
     Char(Option<char>),
-    #[cfg(all(feature = "array", feature = "postgresql"))]
     /// An array value (PostgreSQL).
     Array(Option<Vec<Value<'a>>>),
     #[cfg(feature = "json-1")]
     /// A JSON value.
     Json(Option<serde_json::Value>),
-    #[cfg(feature = "xml")]
     /// A XML value.
     Xml(Option<Cow<'a, str>>),
     #[cfg(feature = "uuid-0_8")]
@@ -110,7 +108,6 @@ impl<'a> fmt::Display for Value<'a> {
             Value::Enum(val) => val.as_ref().map(|v| write!(f, "\"{}\"", v)),
             Value::Boolean(val) => val.map(|v| write!(f, "{}", v)),
             Value::Char(val) => val.map(|v| write!(f, "'{}'", v)),
-            #[cfg(feature = "array")]
             Value::Array(vals) => vals.as_ref().map(|vals| {
                 let len = vals.len();
 
@@ -126,7 +123,6 @@ impl<'a> fmt::Display for Value<'a> {
             }),
             #[cfg(feature = "json-1")]
             Value::Json(val) => val.as_ref().map(|v| write!(f, "{}", v)),
-            #[cfg(feature = "xml")]
             Value::Xml(val) => val.as_ref().map(|v| write!(f, "{}", v)),
             #[cfg(feature = "uuid-0_8")]
             Value::Uuid(val) => val.map(|v| write!(f, "{}", v)),
@@ -164,9 +160,7 @@ impl<'a> From<Value<'a>> for serde_json::Value {
             }),
             #[cfg(feature = "json-1")]
             Value::Json(v) => v,
-            #[cfg(feature = "xml")]
             Value::Xml(cow) => cow.map(|cow| serde_json::Value::String(cow.into_owned())),
-            #[cfg(feature = "array")]
             Value::Array(v) => {
                 v.map(|v| serde_json::Value::Array(v.into_iter().map(serde_json::Value::from).collect()))
             }
@@ -242,7 +236,6 @@ impl<'a> Value<'a> {
     }
 
     /// Creates a new array value.
-    #[cfg(feature = "array")]
     pub fn array<I, V>(value: I) -> Self
     where
         I: IntoIterator<Item = V>,
@@ -282,7 +275,6 @@ impl<'a> Value<'a> {
     }
 
     /// Creates a new XML value.
-    #[cfg(feature = "xml")]
     pub fn xml<T>(value: T) -> Self
     where
         T: Into<Cow<'a, str>>,
@@ -300,7 +292,6 @@ impl<'a> Value<'a> {
             Value::Bytes(b) => b.is_none(),
             Value::Boolean(b) => b.is_none(),
             Value::Char(c) => c.is_none(),
-            #[cfg(feature = "array")]
             Value::Array(v) => v.is_none(),
             #[cfg(feature = "uuid-0_8")]
             Value::Uuid(u) => u.is_none(),
@@ -312,7 +303,6 @@ impl<'a> Value<'a> {
             Value::Time(t) => t.is_none(),
             #[cfg(feature = "json-1")]
             Value::Json(json) => json.is_none(),
-            #[cfg(feature = "xml")]
             Value::Xml(s) => s.is_none(),
         }
     }
@@ -436,7 +426,6 @@ impl<'a> Value<'a> {
     }
 
     /// `true` if the `Value` is an Array.
-    #[cfg(feature = "array")]
     pub fn is_array(&self) -> bool {
         matches!(self, Value::Array(_))
     }
@@ -526,7 +515,6 @@ impl<'a> Value<'a> {
     }
 
     /// Returns a Vec<T> if the value is an array of T, otherwise `None`.
-    #[cfg(all(feature = "array", feature = "postgresql"))]
     pub fn into_vec<T>(self) -> Option<Vec<T>>
     where
         // Implement From<Value>
@@ -719,7 +707,7 @@ impl<'a> IntoIterator for Values<'a> {
     }
 }
 
-#[cfg(all(test, feature = "array", feature = "postgresql"))]
+#[cfg(all(test, feature = "postgresql"))]
 mod tests {
     use super::*;
     #[cfg(feature = "chrono-0_4")]

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -11,13 +11,13 @@ use std::{
     str::FromStr,
 };
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 use serde_json::{Number, Value as JsonValue};
 
-#[cfg(feature = "uuid-0_8")]
+#[cfg(feature = "uuid")]
 use uuid::Uuid;
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 
 /// A value written to the query as-is without parameterization.
@@ -61,21 +61,21 @@ pub enum Value<'a> {
     Char(Option<char>),
     /// An array value (PostgreSQL).
     Array(Option<Vec<Value<'a>>>),
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     /// A JSON value.
     Json(Option<serde_json::Value>),
     /// A XML value.
     Xml(Option<Cow<'a, str>>),
-    #[cfg(feature = "uuid-0_8")]
+    #[cfg(feature = "uuid")]
     /// An UUID value.
     Uuid(Option<Uuid>),
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     /// A datetime value.
     DateTime(Option<DateTime<Utc>>),
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     /// A date value.
     Date(Option<NaiveDate>),
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     /// A time value.
     Time(Option<NaiveTime>),
 }
@@ -121,16 +121,16 @@ impl<'a> fmt::Display for Value<'a> {
                 }
                 write!(f, "]")
             }),
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(val) => val.as_ref().map(|v| write!(f, "{}", v)),
             Value::Xml(val) => val.as_ref().map(|v| write!(f, "{}", v)),
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(val) => val.map(|v| write!(f, "{}", v)),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(val) => val.map(|v| write!(f, "{}", v)),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(val) => val.map(|v| write!(f, "{}", v)),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(val) => val.map(|v| write!(f, "{}", v)),
         };
 
@@ -141,7 +141,7 @@ impl<'a> fmt::Display for Value<'a> {
     }
 }
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 impl<'a> From<Value<'a>> for serde_json::Value {
     fn from(pv: Value<'a>) -> Self {
         let res = match pv {
@@ -158,19 +158,19 @@ impl<'a> From<Value<'a>> for serde_json::Value {
                     .to_string();
                 serde_json::Value::String(s)
             }),
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(v) => v,
             Value::Xml(cow) => cow.map(|cow| serde_json::Value::String(cow.into_owned())),
             Value::Array(v) => {
                 v.map(|v| serde_json::Value::Array(v.into_iter().map(serde_json::Value::from).collect()))
             }
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(u) => u.map(|u| serde_json::Value::String(u.to_hyphenated().to_string())),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(dt) => dt.map(|dt| serde_json::Value::String(dt.to_rfc3339())),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(date) => date.map(|date| serde_json::Value::String(format!("{}", date))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(time) => time.map(|time| serde_json::Value::String(format!("{}", time))),
         };
 
@@ -245,31 +245,31 @@ impl<'a> Value<'a> {
     }
 
     /// Creates a new uuid value.
-    #[cfg(feature = "uuid-0_8")]
+    #[cfg(feature = "uuid")]
     pub fn uuid(value: Uuid) -> Self {
         Value::Uuid(Some(value))
     }
 
     /// Creates a new datetime value.
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     pub fn datetime(value: DateTime<Utc>) -> Self {
         Value::DateTime(Some(value))
     }
 
     /// Creates a new date value.
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     pub fn date(value: NaiveDate) -> Self {
         Value::Date(Some(value))
     }
 
     /// Creates a new time value.
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     pub fn time(value: NaiveTime) -> Self {
         Value::Time(Some(value))
     }
 
     /// Creates a new JSON value.
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     pub fn json(value: serde_json::Value) -> Self {
         Value::Json(Some(value))
     }
@@ -293,15 +293,15 @@ impl<'a> Value<'a> {
             Value::Boolean(b) => b.is_none(),
             Value::Char(c) => c.is_none(),
             Value::Array(v) => v.is_none(),
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(u) => u.is_none(),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(dt) => dt.is_none(),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(d) => d.is_none(),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(t) => t.is_none(),
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(json) => json.is_none(),
             Value::Xml(s) => s.is_none(),
         }
@@ -431,13 +431,13 @@ impl<'a> Value<'a> {
     }
 
     /// `true` if the `Value` is of UUID type.
-    #[cfg(feature = "uuid-0_8")]
+    #[cfg(feature = "uuid")]
     pub fn is_uuid(&self) -> bool {
         matches!(self, Value::Uuid(_))
     }
 
     /// Returns an UUID if the value is of UUID type, otherwise `None`.
-    #[cfg(feature = "uuid-0_8")]
+    #[cfg(feature = "uuid")]
     pub fn as_uuid(&self) -> Option<Uuid> {
         match self {
             Value::Uuid(u) => *u,
@@ -446,13 +446,13 @@ impl<'a> Value<'a> {
     }
 
     /// `true` if the `Value` is a DateTime.
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     pub fn is_datetime(&self) -> bool {
         matches!(self, Value::DateTime(_))
     }
 
     /// Returns a `DateTime` if the value is a `DateTime`, otherwise `None`.
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     pub fn as_datetime(&self) -> Option<DateTime<Utc>> {
         match self {
             Value::DateTime(dt) => *dt,
@@ -461,13 +461,13 @@ impl<'a> Value<'a> {
     }
 
     /// `true` if the `Value` is a Date.
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     pub fn is_date(&self) -> bool {
         matches!(self, Value::Date(_))
     }
 
     /// Returns a `NaiveDate` if the value is a `Date`, otherwise `None`.
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     pub fn as_date(&self) -> Option<NaiveDate> {
         match self {
             Value::Date(dt) => *dt,
@@ -476,13 +476,13 @@ impl<'a> Value<'a> {
     }
 
     /// `true` if the `Value` is a `Time`.
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     pub fn is_time(&self) -> bool {
         matches!(self, Value::Time(_))
     }
 
     /// Returns a `NaiveTime` if the value is a `Time`, otherwise `None`.
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     pub fn as_time(&self) -> Option<NaiveTime> {
         match self {
             Value::Time(time) => *time,
@@ -491,13 +491,13 @@ impl<'a> Value<'a> {
     }
 
     /// `true` if the `Value` is a JSON value.
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     pub fn is_json(&self) -> bool {
         matches!(self, Value::Json(_))
     }
 
     /// Returns a reference to a JSON Value if of Json type, otherwise `None`.
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     pub fn as_json(&self) -> Option<&serde_json::Value> {
         match self {
             Value::Json(Some(j)) => Some(j),
@@ -506,7 +506,7 @@ impl<'a> Value<'a> {
     }
 
     /// Transforms to a JSON Value if of Json type, otherwise `None`.
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     pub fn into_json(self) -> Option<serde_json::Value> {
         match self {
             Value::Json(Some(j)) => Some(j),
@@ -536,20 +536,20 @@ impl<'a> Value<'a> {
 value!(val: i64, Integer, val);
 value!(val: bool, Boolean, val);
 value!(val: Decimal, Real, val);
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 value!(val: JsonValue, Json, val);
-#[cfg(feature = "uuid-0_8")]
+#[cfg(feature = "uuid")]
 value!(val: Uuid, Uuid, val);
 value!(val: &'a str, Text, val.into());
 value!(val: String, Text, val.into());
 value!(val: usize, Integer, i64::try_from(val).unwrap());
 value!(val: i32, Integer, i64::try_from(val).unwrap());
 value!(val: &'a [u8], Bytes, val.into());
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 value!(val: DateTime<Utc>, DateTime, val);
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 value!(val: chrono::NaiveTime, Time, val);
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 value!(val: chrono::NaiveDate, Date, val);
 
 value!(
@@ -611,7 +611,7 @@ impl<'a> TryFrom<Value<'a>> for bool {
     }
 }
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 impl<'a> TryFrom<Value<'a>> for DateTime<Utc> {
     type Error = Error;
 
@@ -710,7 +710,7 @@ impl<'a> IntoIterator for Values<'a> {
 #[cfg(all(test, feature = "postgresql"))]
 mod tests {
     use super::*;
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     use std::str::FromStr;
 
     #[test]
@@ -742,7 +742,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     fn a_parameterized_value_of_datetimes_can_be_converted_into_a_vec() {
         let datetime = DateTime::from_str("2019-07-27T05:30:30Z").expect("parsing date/time");
         let pv = Value::array(vec![datetime]);

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -38,4 +38,5 @@ pub use queryable::*;
 pub use sqlite::*;
 pub use transaction::*;
 #[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgresql"))]
+#[allow(unused_imports)]
 pub(crate) use type_identifier::*;

--- a/src/connector/mssql/conversion.rs
+++ b/src/connector/mssql/conversion.rs
@@ -23,15 +23,15 @@ impl<'a> ToSql for Value<'a> {
             Value::Enum(val) => val.to_sql(),
             Value::Boolean(val) => val.to_sql(),
             Value::Char(val) => val.as_ref().map(|val| format!("{}", val)).into_sql(),
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(val) => val.as_ref().map(|val| serde_json::to_string(&val).unwrap()).into_sql(),
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(val) => val.to_sql(),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(val) => val.to_sql(),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(val) => val.to_sql(),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(val) => val.to_sql(),
             Value::Xml(val) => val.to_sql(),
             Value::Array(_) => panic!("Arrays are not supported on SQL Server."),
@@ -55,32 +55,32 @@ impl TryFrom<ColumnData<'static>> for Value<'static> {
             ColumnData::Guid(uuid) => Value::Uuid(uuid),
             ColumnData::Binary(bytes) => Value::Bytes(bytes),
             numeric @ ColumnData::Numeric(_) => Value::Real(Decimal::from_sql(&numeric)?),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             dt @ ColumnData::DateTime(_) => {
                 use tiberius::time::chrono::{DateTime, NaiveDateTime, Utc};
 
                 let dt = NaiveDateTime::from_sql(&dt)?.map(|dt| DateTime::<Utc>::from_utc(dt, Utc));
                 Value::DateTime(dt)
             }
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             dt @ ColumnData::SmallDateTime(_) => {
                 use tiberius::time::chrono::{DateTime, NaiveDateTime, Utc};
 
                 let dt = NaiveDateTime::from_sql(&dt)?.map(|dt| DateTime::<Utc>::from_utc(dt, Utc));
                 Value::DateTime(dt)
             }
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             dt @ ColumnData::Time(_) => {
                 use tiberius::time::chrono::NaiveTime;
 
                 Value::Time(NaiveTime::from_sql(&dt)?)
             }
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             dt @ ColumnData::Date(_) => {
                 use tiberius::time::chrono::NaiveDate;
                 Value::Date(NaiveDate::from_sql(&dt)?)
             }
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             dt @ ColumnData::DateTime2(_) => {
                 use tiberius::time::chrono::{DateTime, NaiveDateTime, Utc};
 
@@ -88,7 +88,7 @@ impl TryFrom<ColumnData<'static>> for Value<'static> {
 
                 Value::DateTime(dt)
             }
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             dt @ ColumnData::DateTimeOffset(_) => {
                 use tiberius::time::chrono::{DateTime, Utc};
 

--- a/src/connector/mssql/conversion.rs
+++ b/src/connector/mssql/conversion.rs
@@ -33,10 +33,8 @@ impl<'a> ToSql for Value<'a> {
             Value::Date(val) => val.to_sql(),
             #[cfg(feature = "chrono-0_4")]
             Value::Time(val) => val.to_sql(),
-            #[cfg(feature = "xml")]
             Value::Xml(val) => val.to_sql(),
-            #[cfg(feature = "array")]
-            p => todo!("Type {:?} is not supported", p),
+            Value::Array(_) => panic!("Arrays are not supported on SQL Server."),
         }
     }
 }
@@ -96,7 +94,6 @@ impl TryFrom<ColumnData<'static>> for Value<'static> {
 
                 Value::DateTime(DateTime::<Utc>::from_sql(&dt)?)
             }
-            #[cfg(feature = "xml")]
             ColumnData::Xml(cow) => Value::Xml(cow.map(|xml_data| Cow::Owned(xml_data.into_owned().into_string()))),
         };
 

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bit_vec::BitVec;
 use bytes::BytesMut;
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 use chrono::{DateTime, NaiveDateTime, Utc};
 pub(crate) use decimal::DecimalWrapper;
 use postgres_types::{FromSql, ToSql};
@@ -21,7 +21,7 @@ use tokio_postgres::{
     Row as PostgresRow, Statement as PostgresStatement,
 };
 
-#[cfg(feature = "uuid-0_8")]
+#[cfg(feature = "uuid")]
 use uuid::Uuid;
 
 pub fn conv_params<'a>(params: &'a [Value<'a>]) -> Vec<&'a (dyn types::ToSql + Sync)> {
@@ -56,8 +56,10 @@ impl<'a> FromSql<'a> for EnumString {
     }
 }
 
+#[cfg(feature = "chrono")]
 struct TimeTz(chrono::NaiveTime);
 
+#[cfg(feature = "chrono")]
 impl<'a> FromSql<'a> for TimeTz {
     fn from_sql(_ty: &PostgresType, raw: &'a [u8]) -> Result<TimeTz, Box<dyn std::error::Error + Sync + Send>> {
         // We assume UTC.
@@ -157,7 +159,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Real(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::TIMESTAMP => match row.try_get(i)? {
                     Some(val) => {
                         let ts: NaiveDateTime = val;
@@ -166,7 +168,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::DateTime(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::TIMESTAMPTZ => match row.try_get(i)? {
                     Some(val) => {
                         let ts: DateTime<Utc> = val;
@@ -174,17 +176,17 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::DateTime(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::DATE => match row.try_get(i)? {
                     Some(val) => Value::date(val),
                     None => Value::Date(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::TIME => match row.try_get(i)? {
                     Some(val) => Value::time(val),
                     None => Value::Time(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::TIMETZ => match row.try_get(i)? {
                     Some(val) => {
                         let time: TimeTz = val;
@@ -192,7 +194,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Time(None),
                 },
-                #[cfg(feature = "uuid-0_8")]
+                #[cfg(feature = "uuid")]
                 PostgresType::UUID => match row.try_get(i)? {
                     Some(val) => {
                         let val: Uuid = val;
@@ -200,7 +202,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Uuid(None),
                 },
-                #[cfg(feature = "uuid-0_8")]
+                #[cfg(feature = "uuid")]
                 PostgresType::UUID_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<Uuid> = val;
@@ -209,7 +211,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "json-1")]
+                #[cfg(feature = "json")]
                 PostgresType::JSON | PostgresType::JSONB => Value::Json(row.try_get(i)?),
                 PostgresType::INT2_ARRAY => match row.try_get(i)? {
                     Some(val) => {
@@ -259,7 +261,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::TIMESTAMP_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<NaiveDateTime> = val;
@@ -307,7 +309,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::TIMESTAMPTZ_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<DateTime<Utc>> = val;
@@ -316,7 +318,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::DATE_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<chrono::NaiveDate> = val;
@@ -324,7 +326,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::TIME_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<chrono::NaiveTime> = val;
@@ -332,7 +334,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "chrono-0_4")]
+                #[cfg(feature = "chrono")]
                 PostgresType::TIMETZ_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<TimeTz> = val;
@@ -343,6 +345,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
+                #[cfg(feature = "json")]
                 PostgresType::JSON_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<serde_json::Value> = val;
@@ -351,6 +354,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
+                #[cfg(feature = "json")]
                 PostgresType::JSONB_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<serde_json::Value> = val;
@@ -528,12 +532,12 @@ impl<'a> ToSql for Value<'a> {
                 decimal.map(|decimal| DecimalWrapper(decimal).to_sql(ty, out))
             }
             (Value::Real(float), _) => float.map(|float| DecimalWrapper(float).to_sql(ty, out)),
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             (Value::Text(string), &PostgresType::UUID) => string.as_ref().map(|string| {
                 let parsed_uuid: Uuid = string.parse()?;
                 parsed_uuid.to_sql(ty, out)
             }),
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             (Value::Array(values), &PostgresType::UUID_ARRAY) => values.as_ref().map(|values| {
                 let parsed_uuid: Vec<Uuid> = values
                     .iter()
@@ -556,6 +560,7 @@ impl<'a> ToSql for Value<'a> {
                     parsed_ip_addr.to_sql(ty, out)
                 })
             }
+            #[cfg(feature = "json")]
             (Value::Text(string), &PostgresType::JSON) | (Value::Text(string), &PostgresType::JSONB) => string
                 .as_ref()
                 .map(|string| serde_json::from_str::<serde_json::Value>(&string)?.to_sql(ty, out)),
@@ -585,29 +590,29 @@ impl<'a> ToSql for Value<'a> {
             (Value::Boolean(boo), _) => boo.map(|boo| boo.to_sql(ty, out)),
             (Value::Char(c), _) => c.map(|c| (c as i8).to_sql(ty, out)),
             (Value::Array(vec), _) => vec.as_ref().map(|vec| vec.to_sql(ty, out)),
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             (Value::Json(value), _) => value.as_ref().map(|value| value.to_sql(ty, out)),
             (Value::Xml(value), _) => value.as_ref().map(|value| value.to_sql(ty, out)),
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             (Value::Uuid(value), _) => value.map(|value| value.to_sql(ty, out)),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             (Value::DateTime(value), &PostgresType::DATE) => {
                 value.map(|value| value.date().naive_utc().to_sql(ty, out))
             }
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             (Value::Date(value), _) => value.map(|value| value.to_sql(ty, out)),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             (Value::Time(value), _) => value.map(|value| value.to_sql(ty, out)),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             (Value::DateTime(value), &PostgresType::TIME) => value.map(|value| value.time().to_sql(ty, out)),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             (Value::DateTime(value), &PostgresType::TIMETZ) => value.map(|value| {
                 let result = value.time().to_sql(ty, out)?;
                 // We assume UTC. see https://www.postgresql.org/docs/9.5/datatype-datetime.html
                 out.extend_from_slice(&[0; 4]);
                 Ok(result)
             }),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             (Value::DateTime(value), _) => value.map(|value| value.naive_utc().to_sql(ty, out)),
         };
 

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -142,7 +142,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Bytes(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::BYTEA_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<Vec<u8>> = val;
@@ -212,7 +211,6 @@ impl GetRow for PostgresRow {
                 },
                 #[cfg(feature = "json-1")]
                 PostgresType::JSON | PostgresType::JSONB => Value::Json(row.try_get(i)?),
-                #[cfg(feature = "array")]
                 PostgresType::INT2_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<i16> = val;
@@ -221,7 +219,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::INT4_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<i32> = val;
@@ -230,7 +227,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::INT8_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<i64> = val;
@@ -239,7 +235,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::FLOAT4_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<f32> = val;
@@ -248,7 +243,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::FLOAT8_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<f64> = val;
@@ -257,7 +251,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::BOOL_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<bool> = val;
@@ -266,7 +259,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(all(feature = "array", feature = "chrono-0_4"))]
+                #[cfg(feature = "chrono-0_4")]
                 PostgresType::TIMESTAMP_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<NaiveDateTime> = val;
@@ -279,7 +272,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::NUMERIC_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<DecimalWrapper> = val;
@@ -290,7 +282,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::TEXT_ARRAY | PostgresType::NAME_ARRAY | PostgresType::VARCHAR_ARRAY => {
                     match row.try_get(i)? {
                         Some(val) => {
@@ -300,7 +291,6 @@ impl GetRow for PostgresRow {
                         None => Value::Array(None),
                     }
                 }
-                #[cfg(feature = "array")]
                 PostgresType::MONEY_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<NaiveMoney> = val;
@@ -309,7 +299,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::OID_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<u32> = val;
@@ -318,7 +307,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(all(feature = "array", feature = "chrono-0_4"))]
+                #[cfg(feature = "chrono-0_4")]
                 PostgresType::TIMESTAMPTZ_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<DateTime<Utc>> = val;
@@ -327,7 +316,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(all(feature = "array", feature = "chrono-0_4"))]
+                #[cfg(feature = "chrono-0_4")]
                 PostgresType::DATE_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<chrono::NaiveDate> = val;
@@ -335,7 +324,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(all(feature = "array", feature = "chrono-0_4"))]
+                #[cfg(feature = "chrono-0_4")]
                 PostgresType::TIME_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<chrono::NaiveTime> = val;
@@ -343,7 +332,7 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(all(feature = "array", feature = "chrono-0_4"))]
+                #[cfg(feature = "chrono-0_4")]
                 PostgresType::TIMETZ_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<TimeTz> = val;
@@ -354,7 +343,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::JSON_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<serde_json::Value> = val;
@@ -363,7 +351,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::JSONB_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<serde_json::Value> = val;
@@ -393,7 +380,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Text(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::INET_ARRAY | PostgresType::CIDR_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<std::net::IpAddr> = val;
@@ -409,7 +395,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Text(None),
                 },
-                #[cfg(feature = "array")]
                 PostgresType::BIT_ARRAY | PostgresType::VARBIT_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<BitVec> = val;
@@ -423,7 +408,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Array(None),
                 },
-                #[cfg(feature = "xml")]
                 PostgresType::XML => match row.try_get(i)? {
                     Some(val) => {
                         let val: XmlString = val;
@@ -431,7 +415,6 @@ impl GetRow for PostgresRow {
                     }
                     None => Value::Xml(None),
                 },
-                #[cfg(all(feature = "array", feature = "xml"))]
                 PostgresType::XML_ARRAY => match row.try_get(i)? {
                     Some(val) => {
                         let val: Vec<XmlString> = val;
@@ -447,7 +430,6 @@ impl GetRow for PostgresRow {
                         }
                         None => Value::Enum(None),
                     },
-                    #[cfg(feature = "array")]
                     Kind::Array(inner) => match inner.kind() {
                         Kind::Enum(_) => match row.try_get(i)? {
                             Some(val) => {
@@ -602,11 +584,9 @@ impl<'a> ToSql for Value<'a> {
             }),
             (Value::Boolean(boo), _) => boo.map(|boo| boo.to_sql(ty, out)),
             (Value::Char(c), _) => c.map(|c| (c as i8).to_sql(ty, out)),
-            #[cfg(feature = "array")]
             (Value::Array(vec), _) => vec.as_ref().map(|vec| vec.to_sql(ty, out)),
             #[cfg(feature = "json-1")]
             (Value::Json(value), _) => value.as_ref().map(|value| value.to_sql(ty, out)),
-            #[cfg(feature = "xml")]
             (Value::Xml(value), _) => value.as_ref().map(|value| value.to_sql(ty, out)),
             #[cfg(feature = "uuid-0_8")]
             (Value::Uuid(value), _) => value.map(|value| value.to_sql(ty, out)),

--- a/src/connector/result_set.rs
+++ b/src/connector/result_set.rs
@@ -7,7 +7,7 @@ pub use result_row::*;
 use crate::{ast::Value, error::*};
 use std::sync::Arc;
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 use serde_json::Map;
 
 /// Encapsulates a set of results and their respective column names.
@@ -109,7 +109,7 @@ impl Iterator for ResultSetIterator {
     }
 }
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 impl From<ResultSet> for serde_json::Value {
     fn from(result_set: ResultSet) -> Self {
         let columns: Vec<String> = result_set.columns().iter().map(ToString::to_string).collect();

--- a/src/connector/sqlite/conversion.rs
+++ b/src/connector/sqlite/conversion.rs
@@ -204,7 +204,6 @@ impl<'a> ToSql for Value<'a> {
             Value::Boolean(boo) => boo.map(ToSqlOutput::from),
             Value::Char(c) => c.map(|c| ToSqlOutput::from(c as u8)),
             Value::Bytes(bytes) => bytes.as_ref().map(|bytes| ToSqlOutput::from(bytes.as_ref())),
-            #[cfg(feature = "array")]
             Value::Array(_) => {
                 let msg = "Arrays are not supported in SQLite.";
                 let kind = ErrorKind::conversion(msg);
@@ -222,7 +221,6 @@ impl<'a> ToSql for Value<'a> {
 
                 ToSqlOutput::from(stringified)
             }),
-            #[cfg(feature = "xml")]
             Value::Xml(cow) => cow.as_ref().map(|cow| ToSqlOutput::from(cow.as_ref())),
             #[cfg(feature = "uuid-0_8")]
             Value::Uuid(value) => value.map(|value| ToSqlOutput::from(value.to_hyphenated().to_string())),

--- a/src/error.rs
+++ b/src/error.rs
@@ -174,6 +174,7 @@ impl ErrorKind {
         Self::ConversionError(msg.into())
     }
 
+    #[allow(dead_code)]
     pub(crate) fn database_url_is_invalid(msg: impl Into<String>) -> Self {
         Self::DatabaseUrlIsInvalid(msg.into())
     }
@@ -192,7 +193,7 @@ impl From<rust_decimal::Error> for Error {
     }
 }
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 impl From<serde_json::Error> for Error {
     fn from(_: serde_json::Error) -> Self {
         Self::builder(ErrorKind::conversion("Malformed JSON data.")).build()

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -142,8 +142,6 @@ pub use manager::*;
 use crate::connector::ConnectionInfo;
 use mobc::Pool;
 use std::{sync::Arc, time::Duration};
-#[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgresql"))]
-use url::Url;
 
 #[cfg(feature = "sqlite")]
 use std::convert::TryFrom;
@@ -334,7 +332,7 @@ impl Quaint {
             }
             #[cfg(feature = "mysql")]
             s if s.starts_with("mysql") => {
-                let url = crate::connector::MysqlUrl::new(Url::parse(s)?)?;
+                let url = crate::connector::MysqlUrl::new(url::Url::parse(s)?)?;
                 let connection_limit = url.connection_limit();
                 let connect_timeout = url.connect_timeout();
 
@@ -353,7 +351,7 @@ impl Quaint {
             }
             #[cfg(feature = "postgresql")]
             s if s.starts_with("postgres") || s.starts_with("postgresql") => {
-                let url = crate::connector::PostgresUrl::new(Url::parse(s)?)?;
+                let url = crate::connector::PostgresUrl::new(url::Url::parse(s)?)?;
                 let connection_limit = url.connection_limit();
                 let connect_timeout = url.connect_timeout();
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -137,10 +137,8 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
             #[cfg(feature = "json-1")]
             Value::Json(None) => visitor.visit_none(),
 
-            #[cfg(feature = "xml")]
-            Value::Xml(None) => visitor.visit_none(),
-            #[cfg(feature = "xml")]
             Value::Xml(Some(s)) => visitor.visit_string(s.into_owned()),
+            Value::Xml(None) => visitor.visit_none(),
 
             #[cfg(feature = "chrono-0_4")]
             Value::DateTime(Some(dt)) => visitor.visit_string(dt.to_rfc3339()),
@@ -157,12 +155,10 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
             #[cfg(feature = "chrono-0_4")]
             Value::Time(None) => visitor.visit_none(),
 
-            #[cfg(all(feature = "array", feature = "postgresql"))]
             Value::Array(Some(values)) => {
                 let deserializer = serde::de::value::SeqDeserializer::new(values.into_iter());
                 visitor.visit_seq(deserializer)
             }
-            #[cfg(all(feature = "array", feature = "postgresql"))]
             Value::Array(None) => visitor.visit_none(),
         }
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -122,37 +122,37 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
             Value::Real(Some(real)) => visitor.visit_f64(real.to_string().parse::<f64>().unwrap()),
             Value::Real(None) => visitor.visit_none(),
 
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(Some(uuid)) => visitor.visit_string(uuid.to_string()),
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(None) => visitor.visit_none(),
 
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(Some(value)) => {
                 let de = value.into_deserializer();
 
                 de.deserialize_any(visitor)
                     .map_err(|err| serde::de::value::Error::custom(format!("Error deserializing JSON value: {}", err)))
             }
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(None) => visitor.visit_none(),
 
             Value::Xml(Some(s)) => visitor.visit_string(s.into_owned()),
             Value::Xml(None) => visitor.visit_none(),
 
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(Some(dt)) => visitor.visit_string(dt.to_rfc3339()),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(None) => visitor.visit_none(),
 
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(Some(d)) => visitor.visit_string(format!("{}", d)),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(None) => visitor.visit_none(),
 
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(Some(t)) => visitor.visit_string(format!("{}", t)),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(None) => visitor.visit_none(),
 
             Value::Array(Some(values)) => {

--- a/src/single.rs
+++ b/src/single.rs
@@ -8,8 +8,6 @@ use crate::{
 };
 use async_trait::async_trait;
 use std::{fmt, sync::Arc};
-#[cfg(any(feature = "sqlite", feature = "mysql", feature = "postgresql"))]
-use url::Url;
 
 #[cfg(feature = "sqlite")]
 use std::convert::TryFrom;
@@ -141,14 +139,14 @@ impl Quaint {
             }
             #[cfg(feature = "mysql")]
             s if s.starts_with("mysql") => {
-                let url = connector::MysqlUrl::new(Url::parse(s)?)?;
+                let url = connector::MysqlUrl::new(url::Url::parse(s)?)?;
                 let mysql = connector::Mysql::new(url)?;
 
                 Arc::new(mysql) as Arc<dyn Queryable>
             }
             #[cfg(feature = "postgresql")]
             s if s.starts_with("postgres") || s.starts_with("postgresql") => {
-                let url = connector::PostgresUrl::new(Url::parse(s)?)?;
+                let url = connector::PostgresUrl::new(url::Url::parse(s)?)?;
                 let psql = connector::PostgreSql::new(url).await?;
                 Arc::new(psql) as Arc<dyn Queryable>
             }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 mod query;
 pub mod test_api;
 mod types;

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -501,6 +501,7 @@ async fn single_default_value_insert(api: &mut dyn TestApi) -> crate::Result<()>
     Ok(())
 }
 
+#[cfg(any(feature = "mssql", feature = "postgresql"))]
 #[test_each_connector(tags("mssql", "postgres"))]
 async fn returning_insert(api: &mut dyn TestApi) -> crate::Result<()> {
     let table = api.create_table("id int, name varchar(255)").await?;
@@ -627,6 +628,7 @@ async fn single_insert_conflict_do_nothing_single_unique_with_autogen_default(
     Ok(())
 }
 
+#[cfg(any(feature = "mssql", feature = "postgresql"))]
 #[test_each_connector(tags("postgres", "mssql"))]
 async fn single_insert_conflict_do_nothing_with_returning(api: &mut dyn TestApi) -> crate::Result<()> {
     let constraint = api.unique_constraint("id");
@@ -1051,6 +1053,7 @@ async fn unsigned_integers_are_handled(api: &mut dyn TestApi) -> crate::Result<(
     Ok(())
 }
 
+#[cfg(feature = "json")]
 #[test_each_connector(tags("mysql", "postgres"))]
 async fn json_filtering_works(api: &mut dyn TestApi) -> crate::Result<()> {
     let json_type = match api.system() {

--- a/src/tests/types/mssql.rs
+++ b/src/tests/types/mssql.rs
@@ -152,7 +152,7 @@ test_type!(image(
     Value::bytes(b"DEADBEEF".to_vec()),
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(date(
     mssql,
     "date",
@@ -160,7 +160,7 @@ test_type!(date(
     Value::date(chrono::NaiveDate::from_ymd(2020, 4, 20))
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(time(
     mssql,
     "time",
@@ -168,25 +168,25 @@ test_type!(time(
     Value::time(chrono::NaiveTime::from_hms(16, 20, 00))
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(datetime2(mssql, "datetime2", Value::DateTime(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:00Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(datetime(mssql, "datetime", Value::DateTime(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(datetimeoffset(mssql, "datetimeoffset", Value::DateTime(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(smalldatetime(mssql, "smalldatetime", Value::DateTime(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:00Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))

--- a/src/tests/types/mysql.rs
+++ b/src/tests/types/mysql.rs
@@ -164,7 +164,7 @@ test_type!(enum(
     Value::enum_variant("pollicle_dogs")
 ));
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 test_type!(json(
     mysql,
     "json",
@@ -172,13 +172,13 @@ test_type!(json(
     Value::json(serde_json::json!({"this": "is", "a": "json", "number": 2}))
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(date(mysql, "date", Value::Date(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-04-20T00:00:00Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(time(
     mysql,
     "time",
@@ -186,13 +186,13 @@ test_type!(time(
     Value::time(chrono::NaiveTime::from_hms(16, 20, 00))
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(datetime(mysql, "datetime", Value::DateTime(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(timestamp(mysql, "timestamp", {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))

--- a/src/tests/types/postgres.rs
+++ b/src/tests/types/postgres.rs
@@ -10,7 +10,6 @@ test_type!(boolean(
     Value::boolean(false),
 ));
 
-#[cfg(feature = "array")]
 test_type!(boolean_array(
     postgres,
     "boolean[]",
@@ -26,7 +25,6 @@ test_type!(int2(
     Value::integer(i16::MAX),
 ));
 
-#[cfg(feature = "array")]
 test_type!(int2_array(
     postgres,
     "int2[]",
@@ -42,7 +40,6 @@ test_type!(int4(
     Value::integer(i32::MAX),
 ));
 
-#[cfg(feature = "array")]
 test_type!(int4_array(
     postgres,
     "int4[]",
@@ -58,7 +55,6 @@ test_type!(int8(
     Value::integer(i64::MAX),
 ));
 
-#[cfg(feature = "array")]
 test_type!(int8_array(
     postgres,
     "int8[]",
@@ -68,7 +64,6 @@ test_type!(int8_array(
 
 test_type!(oid(postgres, "oid", Value::Integer(None), Value::integer(10000)));
 
-#[cfg(feature = "array")]
 test_type!(oid_array(
     postgres,
     "oid[]",
@@ -262,7 +257,6 @@ test_type!(decimal_35_1(
     )
 ));
 
-#[cfg(feature = "array")]
 test_type!(decimal_array(
     postgres,
     "decimal(10,2)[]",
@@ -277,7 +271,6 @@ test_type!(float4(
     Value::real(rust_decimal::Decimal::from_str("1.1234").unwrap())
 ));
 
-#[cfg(feature = "array")]
 test_type!(float4_array(
     postgres,
     "float4[]",
@@ -295,7 +288,6 @@ test_type!(float8(
     Value::real(rust_decimal::Decimal::from_str("1.12345").unwrap())
 ));
 
-#[cfg(feature = "array")]
 test_type!(float8_array(
     postgres,
     "float8[]",
@@ -313,7 +305,6 @@ test_type!(money(
     Value::real(rust_decimal::Decimal::from_str("1.12").unwrap())
 ));
 
-#[cfg(feature = "array")]
 test_type!(money_array(
     postgres,
     "money[]",
@@ -326,7 +317,6 @@ test_type!(money_array(
 
 test_type!(char(postgres, "char(6)", Value::Text(None), Value::text("foobar")));
 
-#[cfg(feature = "array")]
 test_type!(char_array(
     postgres,
     "char(6)[]",
@@ -341,7 +331,6 @@ test_type!(varchar(
     Value::text("foobar")
 ));
 
-#[cfg(feature = "array")]
 test_type!(varchar_array(
     postgres,
     "varchar(255)[]",
@@ -351,7 +340,6 @@ test_type!(varchar_array(
 
 test_type!(text(postgres, "text", Value::Text(None), Value::text("foobar")));
 
-#[cfg(feature = "array")]
 test_type!(text_array(
     postgres,
     "text[]",
@@ -361,7 +349,6 @@ test_type!(text_array(
 
 test_type!(bit(postgres, "bit(4)", Value::Text(None), Value::text("1001")));
 
-#[cfg(feature = "array")]
 test_type!(bit_array(
     postgres,
     "bit(4)[]",
@@ -376,7 +363,6 @@ test_type!(varbit(
     Value::text("001010101")
 ));
 
-#[cfg(feature = "array")]
 test_type!(varbit_array(
     postgres,
     "varbit(20)[]",
@@ -386,7 +372,6 @@ test_type!(varbit_array(
 
 test_type!(inet(postgres, "inet", Value::Text(None), Value::text("127.0.0.1")));
 
-#[cfg(feature = "array")]
 test_type!(inet_array(
     postgres,
     "inet[]",
@@ -402,7 +387,7 @@ test_type!(json(
     Value::json(serde_json::json!({"foo": "bar"}))
 ));
 
-#[cfg(all(feature = "json-1", feature = "array"))]
+#[cfg(feature = "json-1")]
 test_type!(json_array(
     postgres,
     "json[]",
@@ -421,7 +406,7 @@ test_type!(jsonb(
     Value::json(serde_json::json!({"foo": "bar"}))
 ));
 
-#[cfg(all(feature = "json-1", feature = "array"))]
+#[cfg(feature = "json-1")]
 test_type!(jsonb_array(
     postgres,
     "jsonb[]",
@@ -432,10 +417,8 @@ test_type!(jsonb_array(
     ])
 ));
 
-#[cfg(feature = "xml")]
 test_type!(xml(postgres, "xml", Value::Xml(None), Value::xml("<test>1</test>",)));
 
-#[cfg(all(feature = "xml", feature = "array"))]
 test_type!(xml_array(
     postgres,
     "xml[]",
@@ -459,7 +442,7 @@ test_type!(date(
     Value::date(chrono::NaiveDate::from_ymd(2020, 4, 20))
 ));
 
-#[cfg(all(feature = "chrono-0_4", feature = "array"))]
+#[cfg(feature = "chrono-0_4")]
 test_type!(date_array(
     postgres,
     "date[]",
@@ -475,7 +458,7 @@ test_type!(time(
     Value::time(chrono::NaiveTime::from_hms(16, 20, 00))
 ));
 
-#[cfg(all(feature = "chrono-0_4", feature = "array"))]
+#[cfg(feature = "chrono-0_4")]
 test_type!(time_array(
     postgres,
     "time[]",
@@ -489,7 +472,7 @@ test_type!(timestamp(postgres, "timestamp", Value::DateTime(None), {
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));
 
-#[cfg(all(feature = "chrono-0_4", feature = "array"))]
+#[cfg(feature = "chrono-0_4")]
 test_type!(timestamp_array(postgres, "timestamp[]", Value::Array(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::array(vec![dt.with_timezone(&chrono::Utc)])
@@ -501,7 +484,7 @@ test_type!(timestamptz(postgres, "timestamptz", Value::DateTime(None), {
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));
 
-#[cfg(all(feature = "chrono-0_4", feature = "array"))]
+#[cfg(feature = "chrono-0_4")]
 test_type!(timestamptz_array(postgres, "timestamptz[]", Value::Array(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::array(vec![dt.with_timezone(&chrono::Utc)])
@@ -514,7 +497,6 @@ test_type!(bytea(
     Value::bytes(b"DEADBEEF".to_vec())
 ));
 
-#[cfg(feature = "array")]
 test_type!(bytea_array(
     postgres,
     "bytea[]",
@@ -524,38 +506,3 @@ test_type!(bytea_array(
         Value::bytes(b"BEEFBEEF".to_vec())
     ])
 ));
-
-/* Reserved for SQLx. All of these are broken in the current impl!
-#[cfg(feature = "chrono-0_4")]
-test_type!(timetz(postgres, "timetz", {
-    let dt = chrono::DateTime::parse_from_rfc3339("1970-01-01T19:10:22Z").unwrap();
-    Value::time(chrono::NaiveTime::from_hms(19, 10, 22))
-}));
-
-#[cfg(all(feature = "chrono-0_4", feature = "array"))]
-test_type!(timetz_array(postgres, "timetz[]", {
-    let dt = chrono::DateTime::parse_from_rfc3339("1970-01-01T19:10:22Z").unwrap();
-    Value::array(vec![dt.with_timezone(&chrono::Utc)])
-}));
-
-test_type!(cidr(postgres, "cidr", Value::text("0.0.0.0/0")));
-
-#[cfg(feature = "array")]
-test_type!(cidr_array(
-    postgres,
-    "cidr[]",
-    Value::array(vec![Value::text("127.0.0.1/16"), Value::text("192.168.1.1/24")])
-));
-
-
-
-#[cfg(all(feature = "uuid-0_8", feature = "array"))]
-test_type!(uuid_array(
-    postgres,
-    "uuid[]",
-    Value::array(vec![
-        uuid::Uuid::from_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8").unwrap()
-    ])
-));
-
-*/

--- a/src/tests/types/postgres.rs
+++ b/src/tests/types/postgres.rs
@@ -379,7 +379,7 @@ test_type!(inet_array(
     Value::array(vec![Value::text("127.0.0.1"), Value::text("192.168.1.1")])
 ));
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 test_type!(json(
     postgres,
     "json",
@@ -387,7 +387,7 @@ test_type!(json(
     Value::json(serde_json::json!({"foo": "bar"}))
 ));
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 test_type!(json_array(
     postgres,
     "json[]",
@@ -398,7 +398,7 @@ test_type!(json_array(
     ])
 ));
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 test_type!(jsonb(
     postgres,
     "jsonb",
@@ -406,7 +406,7 @@ test_type!(jsonb(
     Value::json(serde_json::json!({"foo": "bar"}))
 ));
 
-#[cfg(feature = "json-1")]
+#[cfg(feature = "json")]
 test_type!(jsonb_array(
     postgres,
     "jsonb[]",
@@ -426,7 +426,7 @@ test_type!(xml_array(
     Value::array(vec!["<test>1</test>", "<test>2</test>",])
 ));
 
-#[cfg(feature = "uuid-0_8")]
+#[cfg(feature = "uuid")]
 test_type!(uuid(
     postgres,
     "uuid",
@@ -434,7 +434,7 @@ test_type!(uuid(
     Value::uuid(uuid::Uuid::from_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8").unwrap())
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(date(
     postgres,
     "date",
@@ -442,7 +442,7 @@ test_type!(date(
     Value::date(chrono::NaiveDate::from_ymd(2020, 4, 20))
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(date_array(
     postgres,
     "date[]",
@@ -450,7 +450,7 @@ test_type!(date_array(
     Value::array(vec![chrono::NaiveDate::from_ymd(2020, 4, 20)])
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(time(
     postgres,
     "time",
@@ -458,7 +458,7 @@ test_type!(time(
     Value::time(chrono::NaiveTime::from_hms(16, 20, 00))
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(time_array(
     postgres,
     "time[]",
@@ -466,25 +466,25 @@ test_type!(time_array(
     Value::array(vec![chrono::NaiveTime::from_hms(16, 20, 00)])
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(timestamp(postgres, "timestamp", Value::DateTime(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(timestamp_array(postgres, "timestamp[]", Value::Array(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::array(vec![dt.with_timezone(&chrono::Utc)])
 }));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(timestamptz(postgres, "timestamptz", Value::DateTime(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(timestamptz_array(postgres, "timestamptz[]", Value::Array(None), {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::array(vec![dt.with_timezone(&chrono::Utc)])

--- a/src/tests/types/sqlite.rs
+++ b/src/tests/types/sqlite.rs
@@ -1,8 +1,9 @@
 use crate::tests::test_api::sqlite_test_api;
+#[cfg(feature = "chrono")]
 use crate::tests::test_api::TestApi;
+#[cfg(feature = "chrono")]
 use crate::{ast::*, connector::Queryable};
 use std::str::FromStr;
-use test_macros::test_each_connector;
 
 test_type!(integer(
     sqlite,
@@ -42,7 +43,7 @@ test_type!(boolean(
     Value::boolean(false)
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(date(
     sqlite,
     "DATE",
@@ -50,7 +51,7 @@ test_type!(date(
     Value::date(chrono::NaiveDate::from_ymd(1984, 1, 1))
 ));
 
-#[cfg(feature = "chrono-0_4")]
+#[cfg(feature = "chrono")]
 test_type!(datetime(
     sqlite,
     "DATETIME",
@@ -58,8 +59,8 @@ test_type!(datetime(
     Value::datetime(chrono::DateTime::from_str("2020-07-29T09:23:44.458Z").unwrap())
 ));
 
-#[cfg(feature = "chrono-0_4")]
-#[test_each_connector(tags("sqlite"))]
+#[cfg(feature = "chrono")]
+#[test_macros::test_each_connector(tags("sqlite"))]
 async fn test_type_text_datetime_rfc3339(api: &mut dyn TestApi) -> crate::Result<()> {
     let table = api.create_type_table("DATETIME").await?;
     let dt = chrono::Utc::now();
@@ -79,8 +80,8 @@ async fn test_type_text_datetime_rfc3339(api: &mut dyn TestApi) -> crate::Result
     Ok(())
 }
 
-#[cfg(feature = "chrono-0_4")]
-#[test_each_connector(tags("sqlite"))]
+#[cfg(feature = "chrono")]
+#[test_macros::test_each_connector(tags("sqlite"))]
 async fn test_type_text_datetime_rfc2822(api: &mut dyn TestApi) -> crate::Result<()> {
     let table = api.create_type_table("DATETIME").await?;
     let dt = chrono::DateTime::parse_from_rfc2822("Tue, 1 Jul 2003 10:52:37 +0200")
@@ -102,8 +103,8 @@ async fn test_type_text_datetime_rfc2822(api: &mut dyn TestApi) -> crate::Result
     Ok(())
 }
 
-#[cfg(feature = "chrono-0_4")]
-#[test_each_connector(tags("sqlite"))]
+#[cfg(feature = "chrono")]
+#[test_macros::test_each_connector(tags("sqlite"))]
 async fn test_type_text_datetime_custom(api: &mut dyn TestApi) -> crate::Result<()> {
     let table = api.create_type_table("DATETIME").await?;
 

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -173,7 +173,7 @@ impl<'a> Visitor<'a> for Mssql<'a> {
             Value::Bytes(b) => b.map(|b| self.write(format!("0x{}", hex::encode(b)))),
             Value::Boolean(b) => b.map(|b| self.write(if b { 1 } else { 0 })),
             Value::Char(c) => c.map(|c| self.write(format!("'{}'", c))),
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(j) => j.map(|j| self.write(format!("'{}'", serde_json::to_string(&j).unwrap()))),
             Value::Array(_) => {
                 let msg = "Arrays are not supported in T-SQL.";
@@ -184,22 +184,22 @@ impl<'a> Visitor<'a> for Mssql<'a> {
 
                 return Err(builder.build());
             }
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(uuid) => uuid.map(|uuid| {
                 let s = format!("CONVERT(uniqueidentifier, N'{}')", uuid.to_hyphenated().to_string());
                 self.write(s)
             }),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(dt) => dt.map(|dt| {
                 let s = format!("CONVERT(datetimeoffset, N'{}')", dt.to_rfc3339());
                 self.write(s)
             }),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(date) => date.map(|date| {
                 let s = format!("CONVERT(date, N'{}')", date);
                 self.write(s)
             }),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(time) => time.map(|time| {
                 let s = format!("CONVERT(time, N'{}')", time);
                 self.write(s)
@@ -986,7 +986,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     fn test_raw_json() {
         let (sql, params) = Mssql::build(Select::default().value(serde_json::json!({ "foo": "bar" }).raw())).unwrap();
         assert_eq!("SELECT '{\"foo\":\"bar\"}'", sql);
@@ -994,7 +994,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "uuid-0_8")]
+    #[cfg(feature = "uuid")]
     fn test_raw_uuid() {
         let uuid = uuid::Uuid::new_v4();
         let (sql, params) = Mssql::build(Select::default().value(uuid.raw())).unwrap();
@@ -1011,7 +1011,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     fn test_raw_datetime() {
         let dt = chrono::Utc::now();
         let (sql, params) = Mssql::build(Select::default().value(dt.raw())).unwrap();

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -72,7 +72,6 @@ impl<'a> Visitor<'a> for Mysql<'a> {
                 }
                 None => None,
             },
-            #[cfg(all(feature = "array", feature = "postgresql"))]
             Value::Array(_) => {
                 let msg = "Arrays are not supported in MySQL.";
                 let kind = ErrorKind::conversion(msg);
@@ -90,7 +89,6 @@ impl<'a> Visitor<'a> for Mysql<'a> {
             Value::Date(date) => date.map(|date| self.write(format!("'{}'", date))),
             #[cfg(feature = "chrono-0_4")]
             Value::Time(time) => time.map(|time| self.write(format!("'{}'", time))),
-            #[cfg(feature = "xml")]
             Value::Xml(cow) => cow.map(|cow| self.write(format!("'{}'", cow))),
         };
 

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -64,7 +64,7 @@ impl<'a> Visitor<'a> for Mysql<'a> {
             Value::Bytes(b) => b.map(|b| self.write(format!("x'{}'", hex::encode(b)))),
             Value::Boolean(b) => b.map(|b| self.write(b)),
             Value::Char(c) => c.map(|c| self.write(format!("'{}'", c))),
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(j) => match j {
                 Some(ref j) => {
                     let s = serde_json::to_string(&j)?;
@@ -81,13 +81,13 @@ impl<'a> Visitor<'a> for Mysql<'a> {
 
                 return Err(builder.build());
             }
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(uuid) => uuid.map(|uuid| self.write(format!("'{}'", uuid.to_hyphenated().to_string()))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(dt) => dt.map(|dt| self.write(format!("'{}'", dt.to_rfc3339(),))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(date) => date.map(|date| self.write(format!("'{}'", date))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(time) => time.map(|time| self.write(format!("'{}'", time))),
             Value::Xml(cow) => cow.map(|cow| self.write(format!("'{}'", cow))),
         };
@@ -205,7 +205,7 @@ impl<'a> Visitor<'a> for Mysql<'a> {
     }
 
     fn visit_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        #[cfg(feature = "json-1")]
+        #[cfg(feature = "json")]
         {
             if right.is_json_value() || left.is_json_value() {
                 self.write("JSON_CONTAINS")?;
@@ -228,14 +228,14 @@ impl<'a> Visitor<'a> for Mysql<'a> {
             }
         }
 
-        #[cfg(not(feature = "json-1"))]
+        #[cfg(not(feature = "json"))]
         {
             self.visit_regular_equality_comparison(left, right)
         }
     }
 
     fn visit_not_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        #[cfg(feature = "json-1")]
+        #[cfg(feature = "json")]
         {
             if right.is_json_value() || left.is_json_value() {
                 self.write("NOT JSON_CONTAINS")?;
@@ -258,7 +258,7 @@ impl<'a> Visitor<'a> for Mysql<'a> {
             }
         }
 
-        #[cfg(not(feature = "json-1"))]
+        #[cfg(not(feature = "json"))]
         {
             self.visit_regular_difference_comparison(left, right)
         }
@@ -373,7 +373,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     #[test]
     fn equality_with_a_json_value() {
         let expected = expected_values(
@@ -388,7 +388,7 @@ mod tests {
         assert_eq!(expected.1, params);
     }
 
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     #[test]
     fn difference_with_a_json_value() {
         let expected = expected_values(
@@ -493,7 +493,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     fn test_raw_json() {
         let (sql, params) = Mysql::build(Select::default().value(serde_json::json!({ "foo": "bar" }).raw())).unwrap();
         assert_eq!("SELECT CONVERT('{\"foo\":\"bar\"}', JSON)", sql);
@@ -501,7 +501,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "uuid-0_8")]
+    #[cfg(feature = "uuid")]
     fn test_raw_uuid() {
         let uuid = uuid::Uuid::new_v4();
         let (sql, params) = Mysql::build(Select::default().value(uuid.raw())).unwrap();
@@ -512,7 +512,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     fn test_raw_datetime() {
         let dt = chrono::Utc::now();
         let (sql, params) = Mysql::build(Select::default().value(dt.raw())).unwrap();

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -76,7 +76,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
             Value::Bytes(b) => b.map(|b| self.write(format!("E'{}'", hex::encode(b)))),
             Value::Boolean(b) => b.map(|b| self.write(b)),
             Value::Char(c) => c.map(|c| self.write(format!("'{}'", c))),
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(j) => j.map(|j| self.write(format!("'{}'", serde_json::to_string(&j).unwrap()))),
             #[cfg(feature = "postgresql")]
             Value::Array(ary) => ary.map(|ary| {
@@ -94,13 +94,13 @@ impl<'a> Visitor<'a> for Postgres<'a> {
                     Ok(())
                 })
             }),
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(uuid) => uuid.map(|uuid| self.write(format!("'{}'", uuid.to_hyphenated().to_string()))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(dt) => dt.map(|dt| self.write(format!("'{}'", dt.to_rfc3339(),))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(date) => date.map(|date| self.write(format!("'{}'", date))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(time) => time.map(|time| self.write(format!("'{}'", time))),
             Value::Xml(cow) => cow.map(|cow| self.write(format!("'{}'", cow))),
         };
@@ -202,14 +202,14 @@ impl<'a> Visitor<'a> for Postgres<'a> {
     fn visit_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
         // LHS must be cast to json/xml-text if the right is a json/xml-text value and vice versa.
         let right_cast = match left {
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             _ if left.is_json_value() => "::jsonb",
             _ if left.is_xml_value() => "::text",
             _ => "",
         };
 
         let left_cast = match right {
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             _ if right.is_json_value() => "::jsonb",
             _ if right.is_xml_value() => "::text",
             _ => "",
@@ -227,14 +227,14 @@ impl<'a> Visitor<'a> for Postgres<'a> {
     fn visit_not_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
         // LHS must be cast to json/xml-text if the right is a json/xml-text value and vice versa.
         let right_cast = match left {
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             _ if left.is_json_value() => "::jsonb",
             _ if left.is_xml_value() => "::text",
             _ => "",
         };
 
         let left_cast = match right {
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             _ if right.is_json_value() => "::jsonb",
             _ if right.is_xml_value() => "::text",
             _ => "",
@@ -381,7 +381,7 @@ mod tests {
         assert_eq!(expected_sql, sql);
     }
 
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     #[test]
     fn equality_with_a_json_value() {
         let expected = expected_values(
@@ -396,7 +396,7 @@ mod tests {
         assert_eq!(expected.1, params);
     }
 
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     #[test]
     fn equality_with_a_lhs_json_value() {
         // A bit artificial, but checks if the ::jsonb casting is done correctly on the right side as well.
@@ -413,7 +413,7 @@ mod tests {
         assert_eq!(expected.1, params);
     }
 
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     #[test]
     fn difference_with_a_json_value() {
         let expected = expected_values(
@@ -429,7 +429,7 @@ mod tests {
         assert_eq!(expected.1, params);
     }
 
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     #[test]
     fn difference_with_a_lhs_json_value() {
         let expected = expected_values(
@@ -559,7 +559,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     fn test_raw_json() {
         let (sql, params) =
             Postgres::build(Select::default().value(serde_json::json!({ "foo": "bar" }).raw())).unwrap();
@@ -568,7 +568,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "uuid-0_8")]
+    #[cfg(feature = "uuid")]
     fn test_raw_uuid() {
         let uuid = uuid::Uuid::new_v4();
         let (sql, params) = Postgres::build(Select::default().value(uuid.raw())).unwrap();
@@ -579,7 +579,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     fn test_raw_datetime() {
         let dt = chrono::Utc::now();
         let (sql, params) = Postgres::build(Select::default().value(dt.raw())).unwrap();

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -78,7 +78,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
             Value::Char(c) => c.map(|c| self.write(format!("'{}'", c))),
             #[cfg(feature = "json-1")]
             Value::Json(j) => j.map(|j| self.write(format!("'{}'", serde_json::to_string(&j).unwrap()))),
-            #[cfg(all(feature = "array", feature = "postgresql"))]
+            #[cfg(feature = "postgresql")]
             Value::Array(ary) => ary.map(|ary| {
                 self.surround_with("'{", "}'", |ref mut s| {
                     let len = ary.len();
@@ -102,7 +102,6 @@ impl<'a> Visitor<'a> for Postgres<'a> {
             Value::Date(date) => date.map(|date| self.write(format!("'{}'", date))),
             #[cfg(feature = "chrono-0_4")]
             Value::Time(time) => time.map(|time| self.write(format!("'{}'", time))),
-            #[cfg(feature = "xml")]
             Value::Xml(cow) => cow.map(|cow| self.write(format!("'{}'", cow))),
         };
 
@@ -205,7 +204,6 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         let right_cast = match left {
             #[cfg(feature = "json-1")]
             _ if left.is_json_value() => "::jsonb",
-            #[cfg(feature = "xml")]
             _ if left.is_xml_value() => "::text",
             _ => "",
         };
@@ -213,7 +211,6 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         let left_cast = match right {
             #[cfg(feature = "json-1")]
             _ if right.is_json_value() => "::jsonb",
-            #[cfg(feature = "xml")]
             _ if right.is_xml_value() => "::text",
             _ => "",
         };
@@ -232,7 +229,6 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         let right_cast = match left {
             #[cfg(feature = "json-1")]
             _ if left.is_json_value() => "::jsonb",
-            #[cfg(feature = "xml")]
             _ if left.is_xml_value() => "::text",
             _ => "",
         };
@@ -240,7 +236,6 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         let left_cast = match right {
             #[cfg(feature = "json-1")]
             _ if right.is_json_value() => "::jsonb",
-            #[cfg(feature = "xml")]
             _ if right.is_xml_value() => "::text",
             _ => "",
         };
@@ -450,7 +445,6 @@ mod tests {
         assert_eq!(expected.1, params);
     }
 
-    #[cfg(feature = "xml")]
     #[test]
     fn equality_with_a_xml_value() {
         let expected = expected_values(
@@ -466,7 +460,6 @@ mod tests {
         assert_eq!(expected.1, params);
     }
 
-    #[cfg(feature = "xml")]
     #[test]
     fn equality_with_a_lhs_xml_value() {
         let expected = expected_values(
@@ -482,7 +475,6 @@ mod tests {
         assert_eq!(expected.1, params);
     }
 
-    #[cfg(feature = "xml")]
     #[test]
     fn difference_with_a_xml_value() {
         let expected = expected_values(
@@ -498,7 +490,6 @@ mod tests {
         assert_eq!(expected.1, params);
     }
 
-    #[cfg(feature = "xml")]
     #[test]
     fn difference_with_a_lhs_xml_value() {
         let expected = expected_values(

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -48,7 +48,7 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
             Value::Bytes(b) => b.map(|b| self.write(format!("x'{}'", hex::encode(b)))),
             Value::Boolean(b) => b.map(|b| self.write(b)),
             Value::Char(c) => c.map(|c| self.write(format!("'{}'", c))),
-            #[cfg(feature = "json-1")]
+            #[cfg(feature = "json")]
             Value::Json(j) => match j {
                 Some(ref j) => {
                     let s = serde_json::to_string(j)?;
@@ -65,13 +65,13 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
 
                 return Err(builder.build());
             }
-            #[cfg(feature = "uuid-0_8")]
+            #[cfg(feature = "uuid")]
             Value::Uuid(uuid) => uuid.map(|uuid| self.write(format!("'{}'", uuid.to_hyphenated().to_string()))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::DateTime(dt) => dt.map(|dt| self.write(format!("'{}'", dt.to_rfc3339(),))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Date(date) => date.map(|date| self.write(format!("'{}'", date))),
-            #[cfg(feature = "chrono-0_4")]
+            #[cfg(feature = "chrono")]
             Value::Time(time) => time.map(|time| self.write(format!("'{}'", time))),
             Value::Xml(cow) => cow.map(|cow| self.write(format!("'{}'", cow))),
         };
@@ -202,7 +202,7 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use crate::{val, visitor::*};
 
@@ -730,7 +730,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "json-1")]
+    #[cfg(feature = "json")]
     fn test_raw_json() {
         let (sql, params) = Sqlite::build(Select::default().value(serde_json::json!({ "foo": "bar" }).raw())).unwrap();
         assert_eq!("SELECT '{\"foo\":\"bar\"}'", sql);
@@ -738,7 +738,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "uuid-0_8")]
+    #[cfg(feature = "uuid")]
     fn test_raw_uuid() {
         let uuid = uuid::Uuid::new_v4();
         let (sql, params) = Sqlite::build(Select::default().value(uuid.raw())).unwrap();
@@ -749,7 +749,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "chrono-0_4")]
+    #[cfg(feature = "chrono")]
     fn test_raw_datetime() {
         let dt = chrono::Utc::now();
         let (sql, params) = Sqlite::build(Select::default().value(dt.raw())).unwrap();

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -56,7 +56,6 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
                 }
                 None => None,
             },
-            #[cfg(all(feature = "array", feature = "postgresql"))]
             Value::Array(_) => {
                 let msg = "Arrays are not supported in SQLite.";
                 let kind = ErrorKind::conversion(msg);
@@ -74,7 +73,6 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
             Value::Date(date) => date.map(|date| self.write(format!("'{}'", date))),
             #[cfg(feature = "chrono-0_4")]
             Value::Time(time) => time.map(|time| self.write(format!("'{}'", time))),
-            #[cfg(feature = "xml")]
             Value::Xml(cow) => cow.map(|cow| self.write(format!("'{}'", cow))),
         };
 

--- a/test-macros/src/test_each_connector.rs
+++ b/test-macros/src/test_each_connector.rs
@@ -132,12 +132,5 @@ fn test_each_connector_async_wrapper_functions(
         tests.push(test);
     }
 
-    if tests.is_empty() && TAGS_FILTER.is_empty() {
-        return vec![
-            syn::Error::new_spanned(test_function, "All connectors were filtered out for this test.")
-                .to_compile_error(),
-        ];
-    }
-
     tests
 }

--- a/test-setup/Cargo.toml
+++ b/test-setup/Cargo.toml
@@ -12,4 +12,4 @@ bitflags = "1.2.1"
 async-trait = "0.1"
 names = "0.11"
 tokio = { version = "0.2", features = ["rt-threaded"]}
-quaint = { path = "..", features = ["single"] }
+quaint = { path = ".." }

--- a/test-setup/src/lib.rs
+++ b/test-setup/src/lib.rs
@@ -14,10 +14,15 @@ pub fn run_with_tokio<O, F: std::future::Future<Output = O>>(fut: F) -> O {
 
 fn connector_names() -> Vec<(&'static str, Tags)> {
     vec![
+        #[cfg(feature = "mssql")]
         ("mssql", Tags::MSSQL),
+        #[cfg(feature = "mysql")]
         ("mysql", Tags::MYSQL),
+        #[cfg(feature = "mysql")]
         ("mysql8", Tags::MYSQL8),
+        #[cfg(feature = "postgresql")]
         ("postgres", Tags::POSTGRES),
+        #[cfg(feature = "sqlite")]
         ("sqlite", Tags::SQLITE),
     ]
 }


### PR DESCRIPTION
- Remove `xml` and `array` flags
- Remove `full` and `single` variants
- `json-1` => `json`
- `uuid-0_8` => `uuid`
- `chrono-0_4` => `chrono`
- Test more feature combinations on CI
- Deny warnings on CI

Closes: https://github.com/prisma/quaint/issues/216