### PR TITLE
A workaround for `OUTPUT` if having triggers

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -29,7 +29,7 @@ mod union;
 mod update;
 mod values;
 
-pub use column::{Column, DefaultValue};
+pub use column::{Column, DefaultValue, TypeFamily};
 pub use compare::{Comparable, Compare};
 pub use conditions::ConditionTree;
 pub use conjunctive::Conjunctive;

--- a/src/ast/column.rs
+++ b/src/ast/column.rs
@@ -5,6 +5,19 @@ use crate::{
 };
 use std::borrow::Cow;
 
+#[derive(Debug, Clone, Copy)]
+pub enum TypeFamily {
+    Text,
+    Int,
+    Float,
+    Double,
+    Boolean,
+    Uuid,
+    DateTime,
+    Decimal,
+    Bytes,
+}
+
 /// A column definition.
 #[derive(Clone, Debug, Default)]
 pub struct Column<'a> {
@@ -12,6 +25,7 @@ pub struct Column<'a> {
     pub(crate) table: Option<Table<'a>>,
     pub(crate) alias: Option<Cow<'a, str>>,
     pub(crate) default: Option<DefaultValue<'a>>,
+    pub(crate) type_family: Option<TypeFamily>,
 }
 
 /// Defines a default value for a `Column`.
@@ -50,9 +64,7 @@ impl<'a> Column<'a> {
     pub(crate) fn into_bare(self) -> Self {
         Self {
             name: self.name,
-            table: None,
-            alias: None,
-            default: None,
+            ..Default::default()
         }
     }
 
@@ -62,6 +74,12 @@ impl<'a> Column<'a> {
         V: Into<DefaultValue<'a>>,
     {
         self.default = Some(value.into());
+        self
+    }
+
+    /// Sets a type family, used mainly for SQL Server `OUTPUT` hack.
+    pub fn type_family(mut self, type_family: TypeFamily) -> Self {
+        self.type_family = Some(type_family);
         self
     }
 

--- a/src/ast/join.rs
+++ b/src/ast/join.rs
@@ -76,3 +76,20 @@ where
         }
     }
 }
+
+impl<'a> Joinable<'a> for JoinData<'a> {
+    fn on<T>(self, conditions: T) -> JoinData<'a>
+    where
+        T: Into<ConditionTree<'a>>,
+    {
+        let conditions = match self.conditions {
+            ConditionTree::NoCondition => conditions.into(),
+            cond => cond.and(conditions.into()),
+        };
+
+        JoinData {
+            table: self.table,
+            conditions,
+        }
+    }
+}


### PR DESCRIPTION
If a table has triggers, it is not allowed to use the `OUTPUT` statement without `INTO` on `INSERT` or `MERGE` (or `UPDATE`, but we don't care about that yet).

The way Microsoft's Entity Framework goes around this wontfix issue is through a separate table variable, inserting the `OUTPUT` items to it first, then selecting them using a join with the actual table:

```sql
DECLARE @generated_keys table([CustomerID] int)

INSERT Customers (FirstName, LastName)
OUTPUT inserted.[CustomerID] INTO @generated_keys
VALUES ('Steve', 'Brown')

SELECT t.[CustomerID], t.[CustomerGuid], t.[RowVersion], t.[CreatedDate]
FROM @generated_keys AS g
   INNER JOIN Customers AS t
   ON g.[CustomerGUID] = t.[CustomerGUID]
WHERE @@ROWCOUNT > 0
```

What makes this a bit curious is how the table variable can just hold varchars, get numbers or uuids inserted to it and we can still merge with the actual table and with the correct types and select them out.

This additionally adds a `type_family` marker to the `Column`, if we ever want to have a closer mapping to the reality in the table variable. It's probably much faster to at least use something that is closer to an integer when having integer columns, and for sure varchars for varchar columns.

By default the table variable uses `NVARCHAR(255)`, but if the type family is set, we can change the type.