### PR TITLE
Skip using the internal pool of MySQL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ thiserror = "1.0"
 url = "2.1"
 
 either = { version = "1.6", optional = true }
-byteorder = { default-features = false, optional = true, version = "1.3" }
+byteorder = { default-features = false, optional = true, version = ">1.4.0" }
 base64 = { version = "0.12.3", optional = true }
 chrono = { version = "0.4", optional = true }
 lru-cache = { version = "0.1", optional = true }

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -91,7 +91,7 @@ impl Manager for QuaintManager {
             #[cfg(feature = "mysql")]
             QuaintManager::Mysql(url) => {
                 use crate::connector::Mysql;
-                Ok(Box::new(Mysql::new(url.clone())?) as Self::Connection)
+                Ok(Box::new(Mysql::new(url.clone()).await?) as Self::Connection)
             }
 
             #[cfg(feature = "postgresql")]

--- a/src/single.rs
+++ b/src/single.rs
@@ -141,7 +141,7 @@ impl Quaint {
             #[cfg(feature = "mysql")]
             s if s.starts_with("mysql") => {
                 let url = connector::MysqlUrl::new(url::Url::parse(s)?)?;
-                let mysql = connector::Mysql::new(url)?;
+                let mysql = connector::Mysql::new(url).await?;
 
                 Arc::new(mysql) as Arc<dyn Queryable>
             }


### PR DESCRIPTION
We have no need for it, and we can fail immediately when creating the connection, if needed.