### PR TITLE
Add an error message if pool is saturated

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -25,8 +25,10 @@ pub(crate) mod postgres;
 #[cfg(feature = "sqlite")]
 pub(crate) mod sqlite;
 
+#[cfg(any(feature = "mssql", feature = "postgresql", feature = "mysql"))]
 use std::time::Duration;
 
+#[cfg(any(feature = "mssql", feature = "postgresql", feature = "mysql"))]
 use crate::error::{Error, ErrorKind};
 
 #[cfg(feature = "mysql")]
@@ -35,6 +37,7 @@ pub use self::mysql::*;
 pub use self::postgres::*;
 pub use self::result_set::*;
 pub use connection_info::*;
+#[cfg(any(feature = "mssql", feature = "postgresql", feature = "mysql"))]
 use futures::Future;
 #[cfg(feature = "mssql")]
 pub use mssql::*;
@@ -46,6 +49,7 @@ pub use transaction::*;
 #[allow(unused_imports)]
 pub(crate) use type_identifier::*;
 
+#[cfg(any(feature = "mssql", feature = "postgresql", feature = "mysql"))]
 async fn connect_timeout<T, F, E>(duration: Option<Duration>, f: F) -> crate::Result<T>
 where
     F: Future<Output = std::result::Result<T, E>>,

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -115,8 +115,8 @@ impl MysqlUrl {
         let mut use_ssl = false;
         let mut socket = None;
         let mut socket_timeout = None;
-        let mut connect_timeout = None;
-        let mut pool_timeout = None;
+        let mut connect_timeout = Some(Duration::from_secs(5));
+        let mut pool_timeout = Some(Duration::from_secs(5));
 
         for (k, v) in url.query_pairs() {
             match k.as_ref() {
@@ -150,15 +150,23 @@ impl MysqlUrl {
                 }
                 "connect_timeout" => {
                     let as_int = v
-                        .parse()
+                        .parse::<u64>()
                         .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
-                    connect_timeout = Some(Duration::from_secs(as_int));
+
+                    connect_timeout = match as_int {
+                        0 => None,
+                        _ => Some(Duration::from_secs(as_int)),
+                    };
                 }
                 "pool_timeout" => {
                     let as_int = v
-                        .parse()
+                        .parse::<u64>()
                         .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
-                    pool_timeout = Some(Duration::from_secs(as_int));
+
+                    pool_timeout = match as_int {
+                        0 => None,
+                        _ => Some(Duration::from_secs(as_int)),
+                    };
                 }
                 "sslaccept" => {
                     match v.as_ref() {

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -109,6 +109,11 @@ impl MysqlUrl {
         self.query_params.pool_timeout
     }
 
+    /// The socket timeout
+    pub fn socket_timeout(&self) -> Option<Duration> {
+        self.query_params.socket_timeout
+    }
+
     fn parse_query_params(url: &Url) -> Result<MysqlUrlQueryParams, Error> {
         let mut connection_limit = None;
         let mut ssl_opts = my::SslOpts::default();

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -249,8 +249,8 @@ impl PostgresUrl {
         let mut ssl_mode = SslMode::Prefer;
         let mut host = None;
         let mut socket_timeout = None;
-        let mut connect_timeout = None;
-        let mut pool_timeout = None;
+        let mut connect_timeout = Some(Duration::from_secs(5));
+        let mut pool_timeout = Some(Duration::from_secs(5));
         let mut pg_bouncer = false;
         let mut statement_cache_size = 500;
 
@@ -331,13 +331,23 @@ impl PostgresUrl {
                     let as_int = v
                         .parse()
                         .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
-                    connect_timeout = Some(Duration::from_secs(as_int));
+
+                    if as_int == 0 {
+                        connect_timeout = None;
+                    } else {
+                        connect_timeout = Some(Duration::from_secs(as_int));
+                    }
                 }
                 "pool_timeout" => {
                     let as_int = v
                         .parse()
                         .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
-                    pool_timeout = Some(Duration::from_secs(as_int));
+
+                    if as_int == 0 {
+                        pool_timeout = None;
+                    } else {
+                        pool_timeout = Some(Duration::from_secs(as_int));
+                    }
                 }
                 _ => {
                     #[cfg(not(feature = "tracing-log"))]

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -225,8 +225,14 @@ impl PostgresUrl {
         self.query_params.connect_timeout
     }
 
+    /// Pool check_out timeout
     pub fn pool_timeout(&self) -> Option<Duration> {
         self.query_params.pool_timeout
+    }
+
+    /// The socket timeout
+    pub fn socket_timeout(&self) -> Option<Duration> {
+        self.query_params.socket_timeout
     }
 
     pub(crate) fn cache(&self) -> LruCache<String, Statement> {

--- a/src/connector/postgres/error.rs
+++ b/src/connector/postgres/error.rs
@@ -197,9 +197,7 @@ impl From<tokio_postgres::error::Error> for Error {
 
                 match reason.as_str() {
                     "error connecting to server: timed out" => {
-                        let mut builder = Error::builder(ErrorKind::ConnectTimeout(
-                            "tokio-postgres timeout connecting to server".into(),
-                        ));
+                        let mut builder = Error::builder(ErrorKind::ConnectTimeout);
 
                         if let Some(code) = code {
                             builder.set_original_code(code);

--- a/src/connector/sqlite/error.rs
+++ b/src/connector/sqlite/error.rs
@@ -132,7 +132,7 @@ impl From<rusqlite::Error> for Error {
                 },
                 description,
             ) => {
-                let mut builder = Error::builder(ErrorKind::Timeout("SQLite database is busy".into()));
+                let mut builder = Error::builder(ErrorKind::SocketTimeout);
                 builder.set_original_code(format!("{}", extended_code));
 
                 if let Some(description) = description {

--- a/src/connector/timeout.rs
+++ b/src/connector/timeout.rs
@@ -1,0 +1,39 @@
+use crate::error::{Error, ErrorKind};
+use futures::Future;
+use std::time::Duration;
+
+pub async fn connect<T, F, E>(duration: Option<Duration>, f: F) -> crate::Result<T>
+where
+    F: Future<Output = std::result::Result<T, E>>,
+    E: Into<Error>,
+{
+    timeout(duration, f, || Error::builder(ErrorKind::ConnectTimeout).build()).await
+}
+
+pub async fn socket<T, F, E>(duration: Option<Duration>, f: F) -> crate::Result<T>
+where
+    F: Future<Output = std::result::Result<T, E>>,
+    E: Into<Error>,
+{
+    timeout(duration, f, || Error::builder(ErrorKind::SocketTimeout).build()).await
+}
+
+#[cfg(any(feature = "mssql", feature = "postgresql", feature = "mysql"))]
+async fn timeout<T, F, E, EF>(duration: Option<Duration>, f: F, e_f: EF) -> crate::Result<T>
+where
+    F: Future<Output = std::result::Result<T, E>>,
+    EF: FnOnce() -> Error,
+    E: Into<Error>,
+{
+    match duration {
+        Some(duration) => match tokio::time::timeout(duration, f).await {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(err)) => Err(err.into()),
+            Err(_) => Err(e_f()),
+        },
+        None => match f.await {
+            Ok(result) => Ok(result),
+            Err(err) => Err(err.into()),
+        },
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -179,6 +179,10 @@ impl ErrorKind {
     pub(crate) fn database_url_is_invalid(msg: impl Into<String>) -> Self {
         Self::DatabaseUrlIsInvalid(msg.into())
     }
+
+    pub fn connect_timeout(msg: impl Into<String>) -> Self {
+        Self::ConnectTimeout(msg.into())
+    }
 }
 
 impl From<Error> for ErrorKind {

--- a/src/error.rs
+++ b/src/error.rs
@@ -150,6 +150,13 @@ pub enum ErrorKind {
     #[error("Connect timed out ({0})")]
     ConnectTimeout(String),
 
+    #[error(
+        "Timed out fetching a connection from the pool (connection limit: {}, in use: {})",
+        max_open,
+        in_use
+    )]
+    PoolTimeout { max_open: u64, in_use: u64 },
+
     #[error("Operation timed out ({0})")]
     Timeout(String),
 
@@ -180,8 +187,12 @@ impl ErrorKind {
         Self::DatabaseUrlIsInvalid(msg.into())
     }
 
-    pub fn connect_timeout(msg: impl Into<String>) -> Self {
+    pub(crate) fn connect_timeout(msg: impl Into<String>) -> Self {
         Self::ConnectTimeout(msg.into())
+    }
+
+    pub(crate) fn pool_timeout(max_open: u64, in_use: u64) -> Self {
+        Self::PoolTimeout { max_open, in_use }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -187,6 +187,7 @@ impl ErrorKind {
         Self::DatabaseUrlIsInvalid(msg.into())
     }
 
+    #[cfg(feature = "pooled")]
     pub(crate) fn pool_timeout(max_open: u64, in_use: u64) -> Self {
         Self::PoolTimeout { max_open, in_use }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -147,8 +147,8 @@ pub enum ErrorKind {
     #[error("Error in an I/O operation: {0}")]
     IoError(io::Error),
 
-    #[error("Connect timed out ({0})")]
-    ConnectTimeout(String),
+    #[error("Timed out when connecting to the database.")]
+    ConnectTimeout,
 
     #[error(
         "Timed out fetching a connection from the pool (connection limit: {}, in use: {})",
@@ -157,8 +157,8 @@ pub enum ErrorKind {
     )]
     PoolTimeout { max_open: u64, in_use: u64 },
 
-    #[error("Operation timed out ({0})")]
-    Timeout(String),
+    #[error("Timed out during query execution.")]
+    SocketTimeout,
 
     #[error("Error opening a TLS connection. {}", message)]
     TlsError { message: String },
@@ -185,10 +185,6 @@ impl ErrorKind {
     #[allow(dead_code)]
     pub(crate) fn database_url_is_invalid(msg: impl Into<String>) -> Self {
         Self::DatabaseUrlIsInvalid(msg.into())
-    }
-
-    pub(crate) fn connect_timeout(msg: impl Into<String>) -> Self {
-        Self::ConnectTimeout(msg.into())
     }
 
     pub(crate) fn pool_timeout(max_open: u64, in_use: u64) -> Self {
@@ -237,41 +233,6 @@ impl From<num::TryFromIntError> for Error {
 impl From<connection_string::Error> for Error {
     fn from(err: connection_string::Error) -> Error {
         Self::builder(ErrorKind::DatabaseUrlIsInvalid(err.to_string())).build()
-    }
-}
-
-#[cfg(feature = "pooled")]
-#[cfg_attr(feature = "docs", doc(cfg(feature = "pooled")))]
-impl From<mobc::Error<Error>> for Error {
-    fn from(e: mobc::Error<Error>) -> Self {
-        match e {
-            mobc::Error::Inner(e) => e,
-            mobc::Error::Timeout => {
-                let kind = ErrorKind::Timeout("mobc timeout".into());
-
-                let mut builder = Error::builder(kind);
-                builder.set_original_message("Connection timed out.");
-
-                builder.build()
-            }
-            e @ mobc::Error::BadConn => Error::builder(ErrorKind::ConnectionError(Box::new(e))).build(),
-        }
-    }
-}
-
-#[cfg(any(feature = "postgresql", feature = "mysql", feature = "mssql"))]
-#[cfg_attr(
-    feature = "docs",
-    doc(cfg(feature = "postgresql", feature = "mysql", feature = "mssql"))
-)]
-impl From<tokio::time::Elapsed> for Error {
-    fn from(_: tokio::time::Elapsed) -> Self {
-        let kind = ErrorKind::Timeout("tokio timeout".into());
-
-        let mut builder = Error::builder(kind);
-        builder.set_original_message("Query timed out.");
-
-        builder.build()
     }
 }
 

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -434,14 +434,7 @@ impl Quaint {
                     Ok(conn) => conn,
                     Err(mobc::Error::Timeout) => {
                         let state = self.inner.state().await;
-
-                        let message = format!(
-                            "Fetching a connection from the pool timed out. The pool was fully saturated, please consider increasing the `connection_limit`. Current limit: {}, connections in use: {}.",
-                            state.max_open,
-                            state.in_use,
-                        );
-
-                        return Err(Error::builder(ErrorKind::Timeout(message)).build());
+                        return Err(Error::builder(ErrorKind::pool_timeout(state.max_open, state.in_use)).build());
                     }
                     Err(mobc::Error::Inner(e)) => return Err(e),
                     Err(e @ mobc::Error::BadConn) => {

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -55,9 +55,10 @@
 //!   `Timeout` error if it fails to resolve before given time.
 //! - `connect_timeout` defined in seconds. Connecting to a
 //!   database will return a `ConnectTimeout` error if taking more than the
-//!   defined value.
+//!   defined value. Defaults to 5 seconds, if set to 0, no timeout.
 //! - `pool_timeout` defined in seconds. If all connections are in use, the
 //!   database will return a `PoolTimeout` error after waiting for the given time.
+//!   If set to zero, no timeout.
 //! - `pgbouncer` either `true` or `false`. If set, allows usage with the
 //!   pgBouncer connection pool in transaction mode. Additionally a transaction
 //!   is required for every query for the mode to work. When starting a new
@@ -83,9 +84,10 @@
 //!   `Timeout` error if it fails to resolve before given time.
 //! - `connect_timeout` defined in seconds. Connecting to a
 //!   database will return a `ConnectTimeout` error if taking more than the
-//!   defined value.
+//!   defined value. Defaults to 5 seconds, if set to 0, no timeout.
 //! - `pool_timeout` defined in seconds. If all connections are in use, the
 //!   database will return a `PoolTimeout` error after waiting for the given time.
+//!   If set to zero, no timeout.
 //!
 //! ## Microsoft SQL Server
 //!
@@ -99,11 +101,12 @@
 //!   from the server.
 //! - `socketTimeout` defined in seconds. If set, a query will return a
 //!   `Timeout` error if it fails to resolve before given time.
-//! - `connectTimeout` defined in seconds. Connecting to a
+//! - `connectTimeout` defined in seconds (default: 5). Connecting to a
 //!   database will return a `ConnectTimeout` error if taking more than the
-//!   defined value.
-//! - `pool_timeout` defined in seconds. If all connections are in use, the
-//!   database will return a `PoolTimeout` error after waiting for the given time.
+//!   defined value. Defaults to 5 seconds, disabled if set to zero.
+//! - `poolTimeout` defined in seconds. If all connections are in use, the
+//!   database will return a `Timeout` error after waiting for the given time.
+//!   If set to zero, no timeout.
 //! - `connectionLimit` defines the maximum number of connections opened to the
 //!   database.
 //! - `schema` the name of the lookup schema. Only stored to the connection,
@@ -425,7 +428,7 @@ impl Quaint {
     pub async fn check_out(&self) -> crate::Result<PooledConnection> {
         let inner = match self.pool_timeout {
             Some(duration) => {
-                let res = self.inner.get_timeout(duration).await;
+                let res = crate::connector::metrics::check_out(self.inner.get_timeout(duration)).await;
 
                 match res {
                     Ok(conn) => conn,

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -56,6 +56,8 @@
 //! - `connect_timeout` defined in seconds. Connecting to a
 //!   database will return a `ConnectTimeout` error if taking more than the
 //!   defined value.
+//! - `pool_timeout` defined in seconds. If all connections are in use, the
+//!   database will return a `PoolTimeout` error after waiting for the given time.
 //! - `pgbouncer` either `true` or `false`. If set, allows usage with the
 //!   pgBouncer connection pool in transaction mode. Additionally a transaction
 //!   is required for every query for the mode to work. When starting a new
@@ -82,6 +84,8 @@
 //! - `connect_timeout` defined in seconds. Connecting to a
 //!   database will return a `ConnectTimeout` error if taking more than the
 //!   defined value.
+//! - `pool_timeout` defined in seconds. If all connections are in use, the
+//!   database will return a `PoolTimeout` error after waiting for the given time.
 //!
 //! ## Microsoft SQL Server
 //!
@@ -95,9 +99,11 @@
 //!   from the server.
 //! - `socketTimeout` defined in seconds. If set, a query will return a
 //!   `Timeout` error if it fails to resolve before given time.
-//! - `connectTimeout` defined in seconds (default: 5). Connecting to a
+//! - `connectTimeout` defined in seconds. Connecting to a
 //!   database will return a `ConnectTimeout` error if taking more than the
 //!   defined value.
+//! - `pool_timeout` defined in seconds. If all connections are in use, the
+//!   database will return a `PoolTimeout` error after waiting for the given time.
 //! - `connectionLimit` defines the maximum number of connections opened to the
 //!   database.
 //! - `schema` the name of the lookup schema. Only stored to the connection,
@@ -155,7 +161,7 @@ use std::convert::TryFrom;
 pub struct Quaint {
     pub(crate) inner: Pool<QuaintManager>,
     connection_info: Arc<ConnectionInfo>,
-    connect_timeout: Option<Duration>,
+    pool_timeout: Option<Duration>,
 }
 
 /// A `Builder` to construct an instance of a [`Quaint`] pool.
@@ -170,6 +176,7 @@ pub struct Builder {
     health_check_interval: Option<Duration>,
     test_on_check_out: bool,
     connect_timeout: Option<Duration>,
+    pool_timeout: Option<Duration>,
 }
 
 impl Builder {
@@ -186,6 +193,7 @@ impl Builder {
             health_check_interval: None,
             test_on_check_out: false,
             connect_timeout: None,
+            pool_timeout: None,
         })
     }
 
@@ -206,8 +214,8 @@ impl Builder {
         self.max_idle = Some(max_idle);
     }
 
-    /// A timeout for acquiring a connection with the [`check_out`] method. If
-    /// not set, the method never times out.
+    /// A timeout for connecting to the database. If not set, the connection
+    /// never times out.
     ///
     /// # Panics
     ///
@@ -222,6 +230,20 @@ impl Builder {
         );
 
         self.connect_timeout = Some(connect_timeout);
+    }
+
+    /// A timeout for acquiring a connection with the [`check_out`] method. If
+    /// not set, the method never times out.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `pool_timeout` is zero.
+    ///
+    /// [`check_out`]: struct.Quaint.html#method.check_out
+    pub fn pool_timeout(&mut self, pool_timeout: Duration) {
+        assert_ne!(pool_timeout, Duration::from_secs(0), "pool_timeout must be positive");
+
+        self.pool_timeout = Some(pool_timeout);
     }
 
     /// A time how long an idling connection can be kept in the pool before
@@ -283,7 +305,7 @@ impl Builder {
         Quaint {
             inner,
             connection_info,
-            connect_timeout: self.connect_timeout,
+            pool_timeout: self.pool_timeout,
         }
     }
 
@@ -337,17 +359,17 @@ impl Quaint {
             s if s.starts_with("mysql") => {
                 let url = crate::connector::MysqlUrl::new(url::Url::parse(s)?)?;
                 let connection_limit = url.connection_limit();
-                let connect_timeout = url.connect_timeout();
+                let pool_timeout = url.pool_timeout();
 
-                let manager = QuaintManager::Mysql(url);
+                let manager = QuaintManager::Mysql { url };
                 let mut builder = Builder::new(s, manager)?;
 
                 if let Some(limit) = connection_limit {
                     builder.connection_limit(limit);
                 }
 
-                if let Some(timeout) = connect_timeout {
-                    builder.connect_timeout(timeout);
+                if let Some(timeout) = pool_timeout {
+                    builder.pool_timeout(timeout);
                 }
 
                 Ok(builder)
@@ -356,17 +378,17 @@ impl Quaint {
             s if s.starts_with("postgres") || s.starts_with("postgresql") => {
                 let url = crate::connector::PostgresUrl::new(url::Url::parse(s)?)?;
                 let connection_limit = url.connection_limit();
-                let connect_timeout = url.connect_timeout();
+                let pool_timeout = url.pool_timeout();
 
-                let manager = QuaintManager::Postgres(url);
+                let manager = QuaintManager::Postgres { url };
                 let mut builder = Builder::new(s, manager)?;
 
                 if let Some(limit) = connection_limit {
                     builder.connection_limit(limit);
                 }
 
-                if let Some(timeout) = connect_timeout {
-                    builder.connect_timeout(timeout);
+                if let Some(timeout) = pool_timeout {
+                    builder.pool_timeout(timeout);
                 }
 
                 Ok(builder)
@@ -375,17 +397,17 @@ impl Quaint {
             s if s.starts_with("jdbc:sqlserver") || s.starts_with("sqlserver") => {
                 let url = crate::connector::MssqlUrl::new(s)?;
                 let connection_limit = url.connection_limit();
-                let connect_timeout = url.connect_timeout();
+                let pool_timeout = url.pool_timeout();
 
-                let manager = QuaintManager::Mssql(url);
+                let manager = QuaintManager::Mssql { url };
                 let mut builder = Builder::new(s, manager)?;
 
                 if let Some(limit) = connection_limit {
                     builder.connection_limit(limit);
                 }
 
-                if let Some(timeout) = connect_timeout {
-                    builder.connect_timeout(timeout);
+                if let Some(timeout) = pool_timeout {
+                    builder.pool_timeout(timeout);
                 }
 
                 Ok(builder)
@@ -401,45 +423,28 @@ impl Quaint {
 
     /// Reserve a connection from the pool.
     pub async fn check_out(&self) -> crate::Result<PooledConnection> {
-        let inner = match self.connect_timeout {
+        let inner = match self.pool_timeout {
             Some(duration) => {
                 let res = self.inner.get_timeout(duration).await;
 
                 match res {
                     Ok(conn) => conn,
-                    Err(e) => match e {
-                        mobc::Error::Timeout => {
-                            let state = self.inner.state().await;
+                    Err(mobc::Error::Timeout) => {
+                        let state = self.inner.state().await;
 
-                            match (state.max_open, state.in_use) {
-                                // We are at least close to a saturation.
-                                (max_open, in_use) if max_open - in_use <= 2 && in_use > 0 => {
-                                    let message = format!(
-                                        "Fetching a connection from the pool timed out. The pool was saturated, please consider increasing the `connection_limit`. Current limit: `{}`, connections in use: `{}`.",
-                                        max_open,
-                                        in_use,
-                                    );
+                        let message = format!(
+                            "Fetching a connection from the pool timed out. The pool was fully saturated, please consider increasing the `connection_limit`. Current limit: {}, connections in use: {}.",
+                            state.max_open,
+                            state.in_use,
+                        );
 
-                                    return Err(Error::builder(ErrorKind::Timeout(message)).build());
-                                }
-                                // The server is just not responding.
-                                (max_open, in_use) => {
-                                    let message = format!(
-                                        "Fetching a connection from the pool timed out. Creating a new connection timed out. Current limit: `{}`, connections in use: `{}`.",
-                                        max_open,
-                                        in_use,
-                                    );
-
-                                    return Err(Error::builder(ErrorKind::Timeout(message)).build());
-                                }
-                            }
-                        }
-                        mobc::Error::Inner(e) => return Err(e),
-                        e @ mobc::Error::BadConn => {
-                            let error = Error::builder(ErrorKind::ConnectionError(Box::new(e))).build();
-                            return Err(error);
-                        }
-                    },
+                        return Err(Error::builder(ErrorKind::Timeout(message)).build());
+                    }
+                    Err(mobc::Error::Inner(e)) => return Err(e),
+                    Err(e @ mobc::Error::BadConn) => {
+                        let error = Error::builder(ErrorKind::ConnectionError(Box::new(e))).build();
+                        return Err(error);
+                    }
                 }
             }
             None => self.inner.get().await?,

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -4,13 +4,12 @@ use crate::connector::MssqlUrl;
 use crate::connector::MysqlUrl;
 #[cfg(feature = "postgresql")]
 use crate::connector::PostgresUrl;
-use async_trait::async_trait;
-
 use crate::{
     ast,
     connector::{self, Queryable, Transaction, TransactionCapable},
     error::Error,
 };
+use async_trait::async_trait;
 use mobc::{Connection as MobcPooled, Manager};
 
 /// A connection from the pool. Implements
@@ -59,16 +58,16 @@ impl Queryable for PooledConnection {
 #[doc(hidden)]
 pub enum QuaintManager {
     #[cfg(feature = "mysql")]
-    Mysql(MysqlUrl),
+    Mysql { url: MysqlUrl },
 
     #[cfg(feature = "postgresql")]
-    Postgres(PostgresUrl),
+    Postgres { url: PostgresUrl },
 
     #[cfg(feature = "sqlite")]
     Sqlite { url: String, db_name: String },
 
     #[cfg(feature = "mssql")]
-    Mssql(MssqlUrl),
+    Mssql { url: MssqlUrl },
 }
 
 #[async_trait]
@@ -89,19 +88,19 @@ impl Manager for QuaintManager {
             }
 
             #[cfg(feature = "mysql")]
-            QuaintManager::Mysql(url) => {
+            QuaintManager::Mysql { url } => {
                 use crate::connector::Mysql;
                 Ok(Box::new(Mysql::new(url.clone()).await?) as Self::Connection)
             }
 
             #[cfg(feature = "postgresql")]
-            QuaintManager::Postgres(url) => {
+            QuaintManager::Postgres { url } => {
                 use crate::connector::PostgreSql;
                 Ok(Box::new(PostgreSql::new(url.clone()).await?) as Self::Connection)
             }
 
             #[cfg(feature = "mssql")]
-            QuaintManager::Mssql(url) => {
+            QuaintManager::Mssql { url } => {
                 use crate::connector::Mssql;
                 Ok(Box::new(Mssql::new(url.clone()).await?) as Self::Connection)
             }


### PR DESCRIPTION
Better error for the issue in https://github.com/prisma/prisma/issues/4280

Edit: Change of plans. Now we introduce a new parameter `pool_timeout` to error out if pool is saturated. `connect_timeout` will now only be used when connecting to the database.

Both parameters are disabled by default.