### PR TITLE
Default value keyword support

### DIFF
--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -178,6 +178,8 @@ pub enum ExpressionKind<'a> {
     Compare(Compare<'a>),
     /// A single value, column, row or a nested select
     Value(Box<Expression<'a>>),
+    /// DEFAULT keyword, e.g. for `INSERT INTO ... VALUES (..., DEFAULT, ...)`
+    Default,
 }
 
 impl<'a> ExpressionKind<'a> {
@@ -194,6 +196,14 @@ impl<'a> ExpressionKind<'a> {
 pub fn asterisk() -> Expression<'static> {
     Expression {
         kind: ExpressionKind::Asterisk(None),
+        alias: None,
+    }
+}
+
+/// A quick alias to create a default value expression.
+pub fn default_value() -> Expression<'static> {
+    Expression {
+        kind: ExpressionKind::Default,
         alias: None,
     }
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -431,6 +431,7 @@ pub trait Visitor<'a> {
                 }
                 None => self.write("*")?,
             },
+            ExpressionKind::Default => self.write("DEFAULT")?,
         }
 
         if let Some(alias) = value.alias {

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -1653,7 +1653,7 @@ mod tests {
             .value("foo", "bar")
             .value("baz", default_value());
 
-        let (sql, params) = Mssql::build(insert).unwrap();
+        let (sql, _) = Mssql::build(insert).unwrap();
 
         assert_eq!("INSERT INTO [foo] ([foo],[baz]) VALUES (@P1,DEFAULT)", sql);
     }

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -1646,4 +1646,15 @@ mod tests {
             params
         );
     }
+
+    #[test]
+    fn test_default_insert() {
+        let insert = Insert::single_into("foo")
+            .value("foo", "bar")
+            .value("baz", default_value());
+
+        let (sql, params) = Mssql::build(insert).unwrap();
+
+        assert_eq!("INSERT INTO [foo] ([foo],[baz]) VALUES (@P1,DEFAULT)", sql);
+    }
 }

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -541,7 +541,7 @@ mod tests {
             .value("foo", "bar")
             .value("baz", default_value());
 
-        let (sql, params) = Mysql::build(insert).unwrap();
+        let (sql, _) = Mysql::build(insert).unwrap();
 
         assert_eq!("INSERT INTO `foo` (`foo`,`baz`) VALUES (?,DEFAULT)", sql);
     }

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -534,4 +534,15 @@ mod tests {
         assert_eq!(format!("SELECT '{}'", dt.to_rfc3339(),), sql);
         assert!(params.is_empty());
     }
+
+    #[test]
+    fn test_default_insert() {
+        let insert = Insert::single_into("foo")
+            .value("foo", "bar")
+            .value("baz", default_value());
+
+        let (sql, params) = Mysql::build(insert).unwrap();
+
+        assert_eq!("INSERT INTO `foo` (`foo`,`baz`) VALUES (?,DEFAULT)", sql);
+    }
 }

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -614,7 +614,7 @@ mod tests {
             .value("foo", "bar")
             .value("baz", default_value());
 
-        let (sql, params) = Postgres::build(insert).unwrap();
+        let (sql, _) = Postgres::build(insert).unwrap();
 
         assert_eq!("INSERT INTO \"foo\" (\"foo\",\"baz\") VALUES ($1,DEFAULT)", sql);
     }

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -607,4 +607,15 @@ mod tests {
 
         assert_eq!(r#"SELECT "foo".* FROM "foo" WHERE "bar" ILIKE $1"#, sql);
     }
+
+    #[test]
+    fn test_default_insert() {
+        let insert = Insert::single_into("foo")
+            .value("foo", "bar")
+            .value("baz", default_value());
+
+        let (sql, params) = Postgres::build(insert).unwrap();
+
+        assert_eq!("INSERT INTO \"foo\" (\"foo\",\"baz\") VALUES ($1,DEFAULT)", sql);
+    }
 }

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -778,7 +778,7 @@ mod tests {
             .value("foo", "bar")
             .value("baz", default_value());
 
-        let (sql, params) = Sqlite::build(insert).unwrap();
+        let (sql, _) = Sqlite::build(insert).unwrap();
 
         assert_eq!("INSERT INTO `foo` (`foo`, `baz`) VALUES (?,DEFAULT)", sql);
     }

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -771,4 +771,15 @@ mod tests {
         assert_eq!(format!("SELECT '{}'", dt.to_rfc3339(),), sql);
         assert!(params.is_empty());
     }
+
+    #[test]
+    fn test_default_insert() {
+        let insert = Insert::single_into("foo")
+            .value("foo", "bar")
+            .value("baz", default_value());
+
+        let (sql, params) = Sqlite::build(insert).unwrap();
+
+        assert_eq!("INSERT INTO `foo` (`foo`, `baz`) VALUES (?,DEFAULT)", sql);
+    }
 }


### PR DESCRIPTION
Adds support for `default` expression. Can be used in inserts for example: `INSERT INTO table (id, a, b) VALUES (1, default, "b1"), (2, "a2, "b2"),`