### PR TITLE
Better TLS error for MySQL.

### DIFF
--- a/src/connector/mysql/error.rs
+++ b/src/connector/mysql/error.rs
@@ -6,6 +6,10 @@ impl From<my::Error> for Error {
         use my::ServerError;
 
         match e {
+            my::Error::Io(my::IoError::Tls(err)) => Error::builder(ErrorKind::TlsError {
+                message: err.to_string(),
+            })
+            .build(),
             my::Error::Io(io_error) => Error::builder(ErrorKind::ConnectionError(io_error.into())).build(),
             my::Error::Driver(e) => Error::builder(ErrorKind::QueryError(e.into())).build(),
             my::Error::Server(ServerError { ref message, code, .. }) if code == 1062 => {


### PR DESCRIPTION
Also defaults to `accept_invalid_certs` for `sslaccept`, following the
default of official mysql client (and our docs).