### PR TITLE
fix(sqlite): do NOT create two db connections

### DIFF
--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -10,8 +10,7 @@ use crate::{
     visitor::{self, Visitor},
 };
 use async_trait::async_trait;
-use rusqlite::NO_PARAMS;
-use std::{collections::HashSet, convert::TryFrom, path::Path, time::Duration};
+use std::{convert::TryFrom, path::Path, time::Duration};
 use tokio::sync::Mutex;
 
 pub(crate) const DEFAULT_SQLITE_SCHEMA_NAME: &str = "main";
@@ -22,6 +21,7 @@ pub struct Sqlite {
     pub(crate) client: Mutex<rusqlite::Connection>,
     /// This is not a `PathBuf` because we need to `ATTACH` the database to the path, and this can
     /// only be done with UTF-8 paths. This is `None` for purely in-memory databases.
+    #[allow(dead_code)]
     pub(crate) file_path: Option<String>,
 }
 

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -19,10 +19,6 @@ pub(crate) const DEFAULT_SQLITE_SCHEMA_NAME: &str = "main";
 #[cfg_attr(feature = "docs", doc(cfg(feature = "sqlite")))]
 pub struct Sqlite {
     pub(crate) client: Mutex<rusqlite::Connection>,
-    /// This is not a `PathBuf` because we need to `ATTACH` the database to the path, and this can
-    /// only be done with UTF-8 paths. This is `None` for purely in-memory databases.
-    #[allow(dead_code)]
-    pub(crate) file_path: Option<String>,
 }
 
 /// Wraps a connection url and exposes the parsing logic used by Quaint,
@@ -117,7 +113,6 @@ impl TryFrom<&str> for Sqlite {
 
         Ok(Sqlite {
             client,
-            file_path: Some(file_path),
         })
     }
 }
@@ -134,7 +129,6 @@ impl Sqlite {
 
         Ok(Sqlite {
             client: Mutex::new(client),
-            file_path: None,
         })
     }
 }

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -82,7 +82,6 @@ impl Manager for QuaintManager {
                 use crate::connector::Sqlite;
 
                 let mut conn = Sqlite::new(&url)?;
-                conn.attach_database(db_name).await?;
 
                 Ok(Box::new(conn) as Self::Connection)
             }

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -78,10 +78,10 @@ impl Manager for QuaintManager {
     async fn connect(&self) -> crate::Result<Self::Connection> {
         let conn = match self {
             #[cfg(feature = "sqlite")]
-            QuaintManager::Sqlite { url, db_name } => {
+            QuaintManager::Sqlite { url, .. } => {
                 use crate::connector::Sqlite;
 
-                let mut conn = Sqlite::new(&url)?;
+                let conn = Sqlite::new(&url)?;
 
                 Ok(Box::new(conn) as Self::Connection)
             }

--- a/src/single.rs
+++ b/src/single.rs
@@ -132,9 +132,7 @@ impl Quaint {
             #[cfg(feature = "sqlite")]
             s if s.starts_with("file") || s.starts_with("sqlite") => {
                 let params = connector::SqliteParams::try_from(s)?;
-                let mut sqlite = connector::Sqlite::new(&params.file_path)?;
-
-                sqlite.attach_database(&params.db_name).await?;
+                let sqlite = connector::Sqlite::new(&params.file_path)?;
 
                 Arc::new(sqlite) as Arc<dyn Queryable>
             }


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma-engines/issues/1481

This removes support for the path params "db_name". Quaint was using the `ATTACH DATABASE` statement as a hack to scope the db under some custom name.
The `ATTACH DATABASE` statement is initially designed to create another connection to a different db so that one can query multiple dbs. This was causing subtle issues with transactions.

Namely, if inside a transaction, a user would "manually" execute (with `executeRaw`) a write _without_ prefixing the tables with the custom db name (using one connection), and that the QE would also execute a read, this time _with_ the tables prefixed with the db_name (therefore with another connection), this would cause two different connections attempting to do READ/WRITES inside a transaction, causing locks as explained in this doc https://sqlite.org/isolation.html

SQLite _has_ as default db name, it's called `main`. This PR defaults the `db_name` to `main`. This enables:

- The QE to keep referring to the tables using some alias (`main`)
- The users to refer to their tables without using any aliases (that they're not aware of anyway). This is possible because when no alias is used, SQLite will default to using the `main` connection.