### PR TITLE
fix: do not use attach database for in-memory sqlite

### DIFF
--- a/src/connector/connection_info.rs
+++ b/src/connector/connection_info.rs
@@ -34,7 +34,7 @@ pub enum ConnectionInfo {
     Sqlite {
         /// The filesystem path of the SQLite database.
         file_path: String,
-        /// The name the database is bound to (with `ATTACH DATABASE`), if available.
+        /// The name the database is bound to - Always "main"
         db_name: String,
     },
     #[cfg(feature = "sqlite")]

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -238,7 +238,7 @@ mod tests {
 
     #[tokio::test]
     async fn in_memory_sqlite_works() {
-        let conn = Sqlite::new_in_memory("quaint".into()).unwrap();
+        let conn = Sqlite::new_in_memory().unwrap();
 
         conn.raw_cmd("CREATE TABLE test (id INTEGER PRIMARY KEY, txt TEXT NOT NULL);")
             .await
@@ -255,7 +255,7 @@ mod tests {
         assert_eq!(result.get("txt").unwrap(), &Value::text("henlo"));
 
         // Check that we do get a separate, new database.
-        let other_conn = Sqlite::new_in_memory("quaint".into()).unwrap();
+        let other_conn = Sqlite::new_in_memory().unwrap();
 
         let err = other_conn.select(select).await.unwrap_err();
         assert!(matches!(err.kind(), ErrorKind::TableDoesNotExist { .. }));

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -123,9 +123,8 @@ impl Sqlite {
     }
 
     /// Open a new SQLite database in memory.
-    pub fn new_in_memory(attached_name: String) -> crate::Result<Sqlite> {
+    pub fn new_in_memory() -> crate::Result<Sqlite> {
         let client = rusqlite::Connection::open_in_memory()?;
-        rusqlite::Connection::execute(&client, "ATTACH DATABASE ':memory:' AS ?", &[&attached_name])?;
 
         Ok(Sqlite {
             client: Mutex::new(client),

--- a/src/single.rs
+++ b/src/single.rs
@@ -168,12 +168,11 @@ impl Quaint {
     #[cfg(feature = "sqlite")]
     #[cfg_attr(feature = "docs", doc(cfg(sqlite)))]
     /// Open a new SQLite database in memory.
-    pub fn new_in_memory(attached_name: Option<String>) -> crate::Result<Quaint> {
-        let attached_name = attached_name.unwrap_or_else(|| DEFAULT_SQLITE_SCHEMA_NAME.into());
+    pub fn new_in_memory() -> crate::Result<Quaint> {
 
         Ok(Quaint {
-            inner: Arc::new(connector::Sqlite::new_in_memory(attached_name.clone())?),
-            connection_info: Arc::new(ConnectionInfo::InMemorySqlite { db_name: attached_name }),
+            inner: Arc::new(connector::Sqlite::new_in_memory()?),
+            connection_info: Arc::new(ConnectionInfo::InMemorySqlite { db_name: DEFAULT_SQLITE_SCHEMA_NAME.to_owned() }),
         })
     }
 


### PR DESCRIPTION
BREAKING CHANGE: This breaks the `Sqlite::new_in_memory` method.

It removes the `attached_name` param. The db_name now will always default to "main"