### PR TITLE
Set MSRV as 1.48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ authors = [
 description = "An abstraction layer for SQL databases."
 documentation = "https://docs.rs/quaint/"
 edition = "2018"
+rust = "1.48"
 homepage = "https://github.com/prisma/quaint/"
 keywords = ["mysql", "postgresql", "sqlite", "sql"]
 license = "Apache-2.0"


### PR DESCRIPTION
To resolve the compile errors related with unstable `const fn` like below.

```
error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:345:34
    |
345 |             Value::Json(json) => json.is_none(),
    |                                  ^^^^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:324:34
    |
324 |             Value::Integer(i) => i.is_none(),
    |                                  ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:325:32
    |
325 |             Value::Float(i) => i.is_none(),
    |                                ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:326:33
    |
326 |             Value::Double(i) => i.is_none(),
    |                                 ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:327:31
    |
327 |             Value::Text(t) => t.is_none(),
    |                               ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:328:31
    |
328 |             Value::Enum(e) => e.is_none(),
    |                               ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:329:32
    |
329 |             Value::Bytes(b) => b.is_none(),
    |                                ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:330:34
    |
330 |             Value::Boolean(b) => b.is_none(),
    |                                  ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:331:31
    |
331 |             Value::Char(c) => c.is_none(),
    |                               ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:332:32
    |
332 |             Value::Array(v) => v.is_none(),
    |                                ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
FROM rust:1.48.0
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:333:30
    |
333 |             Value::Xml(s) => s.is_none(),
    |                              ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:335:34
    |
335 |             Value::Numeric(r) => r.is_none(),
    |                                  ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:337:31
    |
337 |             Value::Uuid(u) => u.is_none(),
    |                               ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:339:36
    |
339 |             Value::DateTime(dt) => dt.is_none(),
    |                                    ^^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:341:31
    |
341 |             Value::Date(d) => d.is_none(),
    |                               ^^^^^^^^^^^

error: `std::option::Option::<T>::is_none` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:343:31
    |
343 |             Value::Time(t) => t.is_none(),
    |                               ^^^^^^^^^^^

error: `std::option::Option::<T>::as_ref` is not yet stable as a const fn
   --> /usr/local/cargo/git/checkouts/quaint-9f01e008b9a89c14/ac3d9f2/src/ast/values.rs:468:34
    |
468 |             Value::Numeric(d) => d.as_ref(),
    |                                  ^^^^^^^^^^

error: aborting due to 17 previous errors

error: could not compile `quaint`.
```