### PR TITLE
feat: enable positionally inserting joins in a FROM clause

### DIFF
--- a/src/ast/table.rs
+++ b/src/ast/table.rs
@@ -128,7 +128,10 @@ impl<'a> Table<'a> {
         Ok(result)
     }
 
-    pub fn left_join(mut self, join: JoinData<'a>) -> Self {
+    pub fn left_join<J>(mut self, join: J) -> Self
+    where
+        J: Into<JoinData<'a>>,
+    {
         match self.typ {
             TableType::Table(table_name) => {
                 self.typ = TableType::JoinedTable((table_name, vec![Join::Left(join.into())]))

--- a/src/ast/table.rs
+++ b/src/ast/table.rs
@@ -128,6 +128,31 @@ impl<'a> Table<'a> {
         Ok(result)
     }
 
+    /// Adds a `LEFT JOIN` clause to the query, specifically for that table.
+    /// Useful to positionally add a JOIN clause in case you are selecting from multiple tables.
+    ///
+    /// ```rust
+    /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
+    /// # fn main() -> Result<(), quaint::error::Error> {
+    /// let join = "posts".alias("p").on(("p", "visible").equals(true));
+    /// let joined_table = Table::from("users").left_join(join);
+    /// let query = Select::from_table(joined_table).and_from("comments");
+    /// let (sql, params) = Sqlite::build(query)?;
+    ///
+    /// assert_eq!(
+    ///     "SELECT `users`.*, `comments.*` FROM `users` LEFT JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     sql
+    /// );
+    ///
+    /// assert_eq!(
+    ///     vec![
+    ///         Value::from(true),
+    ///     ],
+    ///     params
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn left_join<J>(mut self, join: J) -> Self
     where
         J: Into<JoinData<'a>>,
@@ -148,6 +173,31 @@ impl<'a> Table<'a> {
         self
     }
 
+    /// Adds an `INNER JOIN` clause to the query, specifically for that table.
+    /// Useful to positionally add a JOIN clause in case you are selecting from multiple tables.
+    ///
+    /// ```rust
+    /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
+    /// # fn main() -> Result<(), quaint::error::Error> {
+    /// let join = "posts".alias("p").on(("p", "visible").equals(true));
+    /// let joined_table = Table::from("users").inner_join(join);
+    /// let query = Select::from_table(joined_table).and_from("comments");
+    /// let (sql, params) = Sqlite::build(query)?;
+    ///
+    /// assert_eq!(
+    ///     "SELECT `users`.*, `comments.*` FROM `users` INNER JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     sql
+    /// );
+    ///
+    /// assert_eq!(
+    ///     vec![
+    ///         Value::from(true),
+    ///     ],
+    ///     params
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn inner_join<J>(mut self, join: J) -> Self
     where
         J: Into<JoinData<'a>>,
@@ -168,6 +218,31 @@ impl<'a> Table<'a> {
         self
     }
 
+    /// Adds a `RIGHT JOIN` clause to the query, specifically for that table.
+    /// Useful to positionally add a JOIN clause in case you are selecting from multiple tables.
+    ///
+    /// ```rust
+    /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
+    /// # fn main() -> Result<(), quaint::error::Error> {
+    /// let join = "posts".alias("p").on(("p", "visible").equals(true));
+    /// let joined_table = Table::from("users").right_join(join);
+    /// let query = Select::from_table(joined_table).and_from("comments");
+    /// let (sql, params) = Sqlite::build(query)?;
+    ///
+    /// assert_eq!(
+    ///     "SELECT `users`.*, `comments.*` FROM `users` RIGHT JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     sql
+    /// );
+    ///
+    /// assert_eq!(
+    ///     vec![
+    ///         Value::from(true),
+    ///     ],
+    ///     params
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn right_join<J>(mut self, join: J) -> Self
     where
         J: Into<JoinData<'a>>,
@@ -188,6 +263,31 @@ impl<'a> Table<'a> {
         self
     }
 
+    /// Adds a `FULL JOIN` clause to the query, specifically for that table.
+    /// Useful to positionally add a JOIN clause in case you are selecting from multiple tables.
+    ///
+    /// ```rust
+    /// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
+    /// # fn main() -> Result<(), quaint::error::Error> {
+    /// let join = "posts".alias("p").on(("p", "visible").equals(true));
+    /// let joined_table = Table::from("users").full_join(join);
+    /// let query = Select::from_table(joined_table).and_from("comments");
+    /// let (sql, params) = Sqlite::build(query)?;
+    ///
+    /// assert_eq!(
+    ///     "SELECT `users`.*, `comments.*` FROM `users` FULL JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     sql
+    /// );
+    ///
+    /// assert_eq!(
+    ///     vec![
+    ///         Value::from(true),
+    ///     ],
+    ///     params
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn full_join<J>(mut self, join: J) -> Self
     where
         J: Into<JoinData<'a>>,

--- a/src/ast/table.rs
+++ b/src/ast/table.rs
@@ -140,7 +140,7 @@ impl<'a> Table<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!(
-    ///     "SELECT `users`.*, `comments.*` FROM `users` LEFT JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     "SELECT `users`.*, `comments`.* FROM `users` LEFT JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
     ///     sql
     /// );
     ///
@@ -185,7 +185,7 @@ impl<'a> Table<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!(
-    ///     "SELECT `users`.*, `comments.*` FROM `users` INNER JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     "SELECT `users`.*, `comments`.* FROM `users` INNER JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
     ///     sql
     /// );
     ///
@@ -230,7 +230,7 @@ impl<'a> Table<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!(
-    ///     "SELECT `users`.*, `comments.*` FROM `users` RIGHT JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     "SELECT `users`.*, `comments`.* FROM `users` RIGHT JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
     ///     sql
     /// );
     ///
@@ -275,7 +275,7 @@ impl<'a> Table<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!(
-    ///     "SELECT `users`.*, `comments.*` FROM `users` FULL JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     "SELECT `users`.*, `comments`.* FROM `users` FULL JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
     ///     sql
     /// );
     ///

--- a/src/ast/table.rs
+++ b/src/ast/table.rs
@@ -140,7 +140,9 @@ impl<'a> Table<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!(
-    ///     "SELECT `users`.*, `comments`.* FROM `users` LEFT JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     "SELECT `users`.*, `comments`.* FROM \
+    ///     `users` LEFT JOIN `posts` AS `p` ON `p`.`visible` = ?, \
+    ///     `comments`",
     ///     sql
     /// );
     ///
@@ -185,7 +187,9 @@ impl<'a> Table<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!(
-    ///     "SELECT `users`.*, `comments`.* FROM `users` INNER JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     "SELECT `users`.*, `comments`.* FROM \
+    ///     `users` INNER JOIN `posts` AS `p` ON `p`.`visible` = ?, \
+    ///     `comments`",
     ///     sql
     /// );
     ///
@@ -230,7 +234,9 @@ impl<'a> Table<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!(
-    ///     "SELECT `users`.*, `comments`.* FROM `users` RIGHT JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     "SELECT `users`.*, `comments`.* FROM \
+    ///     `users` RIGHT JOIN `posts` AS `p` ON `p`.`visible` = ?, \
+    ///     `comments`",
     ///     sql
     /// );
     ///
@@ -275,7 +281,9 @@ impl<'a> Table<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!(
-    ///     "SELECT `users`.*, `comments`.* FROM `users` FULL JOIN `posts` AS `p` ON `p`.`visible` = ?, `comments`",
+    ///     "SELECT `users`.*, `comments`.* FROM \
+    ///     `users` FULL JOIN `posts` AS `p` ON `p`.`visible` = ?, \
+    ///     `comments`",
     ///     sql
     /// );
     ///

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -111,9 +111,7 @@ impl TryFrom<&str> for Sqlite {
 
         let client = Mutex::new(conn);
 
-        Ok(Sqlite {
-            client,
-        })
+        Ok(Sqlite { client })
     }
 }
 

--- a/src/single.rs
+++ b/src/single.rs
@@ -169,10 +169,11 @@ impl Quaint {
     #[cfg_attr(feature = "docs", doc(cfg(sqlite)))]
     /// Open a new SQLite database in memory.
     pub fn new_in_memory() -> crate::Result<Quaint> {
-
         Ok(Quaint {
             inner: Arc::new(connector::Sqlite::new_in_memory()?),
-            connection_info: Arc::new(ConnectionInfo::InMemorySqlite { db_name: DEFAULT_SQLITE_SCHEMA_NAME.to_owned() }),
+            connection_info: Arc::new(ConnectionInfo::InMemorySqlite {
+                db_name: DEFAULT_SQLITE_SCHEMA_NAME.to_owned(),
+            }),
         })
     }
 

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -377,6 +377,7 @@ async fn table_inner_join(api: &mut dyn TestApi) -> crate::Result<()> {
             .as_str()
             .on((table1.as_str(), "id").equals(Column::from((&table2, "t1_id")))),
     );
+
     let query = Select::from_table(joined_table)
         // Select from a third table to ensure that the JOIN is specifically applied on the table1
         .and_from(&table3)
@@ -469,6 +470,7 @@ async fn table_left_join(api: &mut dyn TestApi) -> crate::Result<()> {
             .as_str()
             .on((&table1, "id").equals(Column::from((&table2, "t1_id")))),
     );
+
     let query = Select::from_table(joined_table)
         // Select from a third table to ensure that the JOIN is specifically applied on the table1
         .and_from(&table3)

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -351,6 +351,58 @@ async fn inner_join(api: &mut dyn TestApi) -> crate::Result<()> {
 }
 
 #[test_each_connector]
+async fn table_inner_join(api: &mut dyn TestApi) -> crate::Result<()> {
+    let table1 = api.create_table("id int, name varchar(255)").await?;
+    let table2 = api.create_table("t1_id int, is_cat int").await?;
+    let table3 = api.create_table("id int, foo int").await?;
+
+    let insert = Insert::multi_into(&table1, vec!["id", "name"])
+        .values(vec![Value::integer(1), Value::text("Musti")])
+        .values(vec![Value::integer(2), Value::text("Belka")]);
+
+    api.conn().insert(insert.into()).await?;
+
+    let insert = Insert::multi_into(&table2, vec!["t1_id", "is_cat"])
+        .values(vec![Value::integer(1), Value::integer(1)])
+        .values(vec![Value::integer(2), Value::integer(0)]);
+
+    api.conn().insert(insert.into()).await?;
+
+    let insert = Insert::multi_into(&table3, vec!["id", "foo"]).values(vec![Value::integer(1), Value::integer(1)]);
+
+    api.conn().insert(insert.into()).await?;
+
+    let joined_table = Table::from(&table1).inner_join(
+        table2
+            .as_str()
+            .on((table1.as_str(), "id").equals(Column::from((&table2, "t1_id")))),
+    );
+    let query = Select::from_table(joined_table)
+        // Select from a third table to ensure that the JOIN is specifically applied on the table1
+        .and_from(&table3)
+        .column((&table1, "name"))
+        .column((&table2, "is_cat"))
+        .column((&table3, "foo"))
+        .order_by(Column::from((&table1, "id")).ascend());
+
+    let res = api.conn().select(query).await?;
+
+    assert_eq!(2, res.len());
+
+    let row = res.get(0).unwrap();
+    assert_eq!(Some("Musti"), row["name"].as_str());
+    assert_eq!(Some(true), row["is_cat"].as_bool());
+    assert_eq!(Some(true), row["foo"].as_bool());
+
+    let row = res.get(1).unwrap();
+    assert_eq!(Some("Belka"), row["name"].as_str());
+    assert_eq!(Some(false), row["is_cat"].as_bool());
+    assert_eq!(Some(true), row["foo"].as_bool());
+
+    Ok(())
+}
+
+#[test_each_connector]
 async fn left_join(api: &mut dyn TestApi) -> crate::Result<()> {
     let table1 = api.create_table("id int, name varchar(255)").await?;
     let table2 = api.create_table("t1_id int, is_cat int").await?;
@@ -395,6 +447,7 @@ async fn left_join(api: &mut dyn TestApi) -> crate::Result<()> {
 async fn table_left_join(api: &mut dyn TestApi) -> crate::Result<()> {
     let table1 = api.create_table("id int, name varchar(255)").await?;
     let table2 = api.create_table("t1_id int, is_cat int").await?;
+    let table3 = api.create_table("id int, foo int").await?;
 
     let insert = Insert::multi_into(&table1, vec!["id", "name"])
         .values(vec![Value::integer(1), Value::text("Musti")])
@@ -407,13 +460,40 @@ async fn table_left_join(api: &mut dyn TestApi) -> crate::Result<()> {
 
     api.conn().insert(insert.into()).await?;
 
-    let join = table2
-        .alias("t1")
-        .on((&table1, "id").equals(Column::from(("t1", "t1_id"))));
-    let joined_table = Table::from(table1).left_join(join);
-    let query = Select::from_table(joined_table);
+    let insert = Insert::multi_into(&table3, vec!["id", "foo"]).values(vec![Value::integer(1), Value::integer(1)]);
+
+    api.conn().insert(insert.into()).await?;
+
+    let joined_table = Table::from(&table1).left_join(
+        table2
+            .as_str()
+            .on((&table1, "id").equals(Column::from((&table2, "t1_id")))),
+    );
+    let query = Select::from_table(joined_table)
+        // Select from a third table to ensure that the JOIN is specifically applied on the table1
+        .and_from(&table3)
+        .column((&table1, "name"))
+        .column((&table2, "is_cat"))
+        .column((&table3, "foo"))
+        .order_by(Column::from((&table1, "id")).ascend());
 
     let res = api.conn().select(query).await?;
+
+    println!("{:?}", &res);
+
+    assert_eq!(2, res.len());
+
+    let row = res.get(0).unwrap();
+    assert_eq!(Some("Musti"), row["name"].as_str());
+    assert_eq!(Some(true), row["is_cat"].as_bool());
+    assert_eq!(Some(true), row["foo"].as_bool());
+
+    let row = res.get(1).unwrap();
+    assert_eq!(Some("Belka"), row["name"].as_str());
+    assert_eq!(None, row["is_cat"].as_bool());
+    assert_eq!(Some(true), row["foo"].as_bool());
+
+    Ok(())
 }
 
 #[test_each_connector]

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -1657,4 +1657,20 @@ mod tests {
 
         assert_eq!("INSERT INTO [foo] ([foo],[baz]) VALUES (@P1,DEFAULT)", sql);
     }
+
+    #[test]
+    fn join_is_inserted_positionally() {
+        let joined_table = Table::from("User").left_join(
+            "Post"
+                .alias("p")
+                .on(("p", "userId").equals(Column::from(("User", "id")))),
+        );
+        let q = Select::from_table(joined_table).and_from("Toto");
+        let (sql, _) = Mssql::build(q).unwrap();
+
+        assert_eq!(
+            "SELECT [User].*, [Toto].* FROM [User] LEFT JOIN [Post] AS [p] ON [p].[userId] = [User].[id], [Toto]",
+            sql
+        );
+    }
 }

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -545,4 +545,20 @@ mod tests {
 
         assert_eq!("INSERT INTO `foo` (`foo`,`baz`) VALUES (?,DEFAULT)", sql);
     }
+
+    #[test]
+    fn join_is_inserted_positionally() {
+        let joined_table = Table::from("User").left_join(
+            "Post"
+                .alias("p")
+                .on(("p", "userId").equals(Column::from(("User", "id")))),
+        );
+        let q = Select::from_table(joined_table).and_from("Toto");
+        let (sql, _) = Mysql::build(q).unwrap();
+
+        assert_eq!(
+            "SELECT `User`.*, `Toto`.* FROM `User` LEFT JOIN `Post` AS `p` ON `p`.`userId` = `User`.`id`, `Toto`",
+            sql
+        );
+    }
 }

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -618,4 +618,17 @@ mod tests {
 
         assert_eq!("INSERT INTO \"foo\" (\"foo\",\"baz\") VALUES ($1,DEFAULT)", sql);
     }
+
+    #[test]
+    fn join_is_inserted_positionally() {
+        let joined_table = Table::from("User").left_join(
+            "Post"
+                .alias("p")
+                .on(("p", "userId").equals(Column::from(("User", "id")))),
+        );
+        let q = Select::from_table(joined_table).and_from("Toto");
+        let (sql, _) = Postgres::build(q).unwrap();
+
+        assert_eq!("SELECT \"User\".*, \"Toto\".* FROM \"User\" LEFT JOIN \"Post\" AS \"p\" ON \"p\".\"userId\" = \"User\".\"id\", \"Toto\"", sql);
+    }
 }

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -782,4 +782,20 @@ mod tests {
 
         assert_eq!("INSERT INTO `foo` (`foo`, `baz`) VALUES (?,DEFAULT)", sql);
     }
+
+    #[test]
+    fn join_is_inserted_positionally() {
+        let joined_table = Table::from("User").left_join(
+            "Post"
+                .alias("p")
+                .on(("p", "userId").equals(Column::from(("User", "id")))),
+        );
+        let q = Select::from_table(joined_table).and_from("Toto");
+        let (sql, _) = Sqlite::build(q).unwrap();
+
+        assert_eq!(
+            "SELECT `User`.*, `Toto`.* FROM `User` LEFT JOIN `Post` AS `p` ON `p`.`userId` = `User`.`id`, `Toto`",
+            sql
+        );
+    }
 }


### PR DESCRIPTION
## Overview

Add joins methods to the `Table` trait so that joins can be inserted positionally into the Query AST.

This enables, for instance, to render such a query:

```
SELECT
  *
FROM
  "User" LEFT JOIN "Post" AS "p" ON "p"."userId" = "User"."id",
  "Post"
```