### PR TITLE
Added support for 'ROW_TO_JSON' function for postgresql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+
+- Added support for `ROW_TO_JSON` function in postgresql
 
 ## v0.2.0-alpha.13
 

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -5,6 +5,7 @@ mod lower;
 mod maximum;
 mod minimum;
 mod row_number;
+mod row_to_json;
 mod sum;
 mod upper;
 
@@ -15,6 +16,8 @@ pub use lower::*;
 pub use maximum::*;
 pub use minimum::*;
 pub use row_number::*;
+#[cfg(all(feature = "json", feature = "postgresql"))]
+pub use row_to_json::*;
 pub use sum::*;
 pub use upper::*;
 
@@ -31,6 +34,8 @@ pub struct Function<'a> {
 /// A database function type
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum FunctionType<'a> {
+    #[cfg(all(feature = "json", feature = "postgresql"))]
+    RowToJson(RowToJson<'a>),
     RowNumber(RowNumber<'a>),
     Count(Count<'a>),
     AggregateToString(AggregateToString<'a>),
@@ -53,6 +58,9 @@ impl<'a> Aliasable<'a> for Function<'a> {
         self
     }
 }
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+function!(RowToJson);
 
 function!(
     RowNumber,

--- a/src/ast/function/row_to_json.rs
+++ b/src/ast/function/row_to_json.rs
@@ -1,0 +1,50 @@
+use super::Function;
+use crate::ast::Table;
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "postgresql")))]
+#[cfg(all(feature = "json", feature = "postgresql"))]
+/// A representation of the `ROW_TO_JSON` function in the database.
+/// Only for `Postgresql`
+pub struct RowToJson<'a> {
+    pub(crate) expr: Table<'a>,
+    pub(crate) pretty_print: bool,
+}
+
+/// Return the given table in `JSON` format.
+///
+/// Only available for `Postgresql`
+///
+/// ```no_run
+/// # use quaint::{ast::*, visitor::{Visitor, Postgres}};
+/// # fn main() -> Result<(), quaint::error::Error> {
+/// let cte = Select::default()
+/// 	.value(val!("hello_world").alias("toto"))
+/// 	.into_cte("one");
+/// let select = Select::from_table("one")
+/// 	.value(row_to_json("one", false))
+/// 	.with(cte);
+/// let result = api.conn().select(select).await?;
+///
+/// assert_eq!(
+/// 	Value::Json(Some(serde_json::json!({
+/// 		"toto": "hello_world"
+/// 	}))),
+/// 	result.into_single().unwrap()[0]
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[cfg_attr(feature = "docs", doc(cfg(feature = "postgresql")))]
+#[cfg(all(feature = "json", feature = "postgresql"))]
+pub fn row_to_json<'a, T>(expr: T, pretty_print: bool) -> Function<'a>
+where
+    T: Into<Table<'a>>,
+{
+    let fun = RowToJson {
+        expr: expr.into(),
+        pretty_print,
+    };
+
+    fun.into()
+}

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -1457,6 +1457,44 @@ async fn enum_values(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
+#[test_each_connector(tags("postgresql"))]
+#[cfg(all(feature = "json", feature = "postgresql"))]
+async fn row_to_json_normal(api: &mut dyn TestApi) -> crate::Result<()> {
+    let cte = Select::default()
+        .value(val!("hello_world").alias("toto"))
+        .into_cte("one");
+    let select = Select::from_table("one").value(row_to_json("one", false)).with(cte);
+    let result = api.conn().select(select).await?;
+
+    assert_eq!(
+        Value::Json(Some(serde_json::json!({
+            "toto": "hello_world"
+        }))),
+        result.into_single().unwrap()[0]
+    );
+
+    Ok(())
+}
+
+#[test_each_connector(tags("postgresql"))]
+#[cfg(all(feature = "json", feature = "postgresql"))]
+async fn row_to_json_pretty(api: &mut dyn TestApi) -> crate::Result<()> {
+    let cte = Select::default()
+        .value(val!("hello_world").alias("toto"))
+        .into_cte("one");
+    let select = Select::from_table("one").value(row_to_json("one", true)).with(cte);
+    let result = api.conn().select(select).await?;
+
+    assert_eq!(
+        Value::Json(Some(serde_json::json!({
+            "toto": "hello_world"
+        }))),
+        result.into_single().unwrap()[0]
+    );
+
+    Ok(())
+}
+
 #[test_each_connector(ignore("mysql"))]
 async fn single_common_table_expression(api: &mut dyn TestApi) -> crate::Result<()> {
     let cte = Select::default()

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -921,6 +921,11 @@ pub trait Visitor<'a> {
             FunctionType::AggregateToString(agg) => {
                 self.visit_aggregate_to_string(agg.value.as_ref().clone())?;
             }
+            #[cfg(all(feature = "json", feature = "postgresql"))]
+            FunctionType::RowToJson(row_to_json) => {
+                self.write("ROW_TO_JSON")?;
+                self.surround_with("(", ")", |ref mut s| s.visit_table(row_to_json.expr, false))?
+            }
             FunctionType::Average(avg) => {
                 self.visit_average(avg)?;
             }


### PR DESCRIPTION
PR to support [the issue](https://github.com/prisma/quaint/issues/259) I just opened.

Maybe it would be nice to create a new `Function` type that would be accessible only for the `Postgresql` visitor. In its current state, every visitor could use the newly exposed function, but only `Postgresql` would be compatible.

I'd love some feedback !