### PR TITLE
Expose maximum connection lifetimes

### DIFF
--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -75,6 +75,8 @@ pub(crate) struct MssqlQueryParams {
     connect_timeout: Option<Duration>,
     pool_timeout: Option<Duration>,
     transaction_isolation_level: Option<IsolationLevel>,
+    max_connection_lifetime: Option<Duration>,
+    max_idle_connection_lifetime: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -186,6 +188,16 @@ impl MssqlUrl {
     pub fn connection_string(&self) -> &str {
         &self.connection_string
     }
+
+    /// The maximum connection lifetime
+    pub fn max_connection_lifetime(&self) -> Option<Duration> {
+        self.query_params.max_connection_lifetime()
+    }
+
+    /// The maximum idle connection lifetime
+    pub fn max_idle_connection_lifetime(&self) -> Option<Duration> {
+        self.query_params.max_idle_connection_lifetime()
+    }
 }
 
 impl MssqlQueryParams {
@@ -223,6 +235,14 @@ impl MssqlQueryParams {
 
     fn pool_timeout(&self) -> Option<Duration> {
         self.pool_timeout
+    }
+
+    fn max_connection_lifetime(&self) -> Option<Duration> {
+        self.max_connection_lifetime
+    }
+
+    fn max_idle_connection_lifetime(&self) -> Option<Duration> {
+        self.max_idle_connection_lifetime
     }
 }
 
@@ -467,6 +487,16 @@ impl MssqlUrl {
             .transpose()?
             .unwrap_or(false);
 
+        let max_connection_lifetime = props
+            .remove("max_connection_lifetime")
+            .map(|param| param.parse().map(Duration::from_secs))
+            .transpose()?;
+
+        let max_idle_connection_lifetime = props
+            .remove("max_idle_connection_lifetime")
+            .map(|param| param.parse().map(Duration::from_secs))
+            .transpose()?;
+
         Ok(MssqlQueryParams {
             encrypt,
             port,
@@ -481,6 +511,8 @@ impl MssqlUrl {
             connect_timeout,
             pool_timeout,
             transaction_isolation_level,
+            max_connection_lifetime,
+            max_idle_connection_lifetime,
         })
     }
 }

--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -487,15 +487,26 @@ impl MssqlUrl {
             .transpose()?
             .unwrap_or(false);
 
-        let max_connection_lifetime = props
+        let mut max_connection_lifetime = props
             .remove("max_connection_lifetime")
             .map(|param| param.parse().map(Duration::from_secs))
             .transpose()?;
 
-        let max_idle_connection_lifetime = props
+        match max_connection_lifetime {
+            Some(dur) if dur.as_secs() == 0 => max_connection_lifetime = None,
+            _ => (),
+        }
+
+        let mut max_idle_connection_lifetime = props
             .remove("max_idle_connection_lifetime")
             .map(|param| param.parse().map(Duration::from_secs))
             .transpose()?;
+
+        match max_idle_connection_lifetime {
+            None => max_idle_connection_lifetime = Some(Duration::from_secs(300)),
+            Some(dur) if dur.as_secs() == 0 => max_idle_connection_lifetime = None,
+            _ => (),
+        }
 
         Ok(MssqlQueryParams {
             encrypt,

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -132,7 +132,7 @@ impl MysqlUrl {
         let mut connect_timeout = Some(Duration::from_secs(5));
         let mut pool_timeout = Some(Duration::from_secs(10));
         let mut max_connection_lifetime = None;
-        let mut max_idle_connection_lifetime = None;
+        let mut max_idle_connection_lifetime = Some(Duration::from_secs(300));
 
         for (k, v) in url.query_pairs() {
             match k.as_ref() {

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -111,6 +111,16 @@ impl MysqlUrl {
         self.query_params.socket_timeout
     }
 
+    /// The maximum connection lifetime
+    pub fn max_connection_lifetime(&self) -> Option<Duration> {
+        self.query_params.max_connection_lifetime
+    }
+
+    /// The maximum idle connection lifetime
+    pub fn max_idle_connection_lifetime(&self) -> Option<Duration> {
+        self.query_params.max_idle_connection_lifetime
+    }
+
     fn parse_query_params(url: &Url) -> Result<MysqlUrlQueryParams, Error> {
         let mut ssl_opts = my::SslOpts::default();
         ssl_opts = ssl_opts.with_danger_accept_invalid_certs(true);
@@ -121,6 +131,8 @@ impl MysqlUrl {
         let mut socket_timeout = None;
         let mut connect_timeout = Some(Duration::from_secs(5));
         let mut pool_timeout = Some(Duration::from_secs(10));
+        let mut max_connection_lifetime = None;
+        let mut max_idle_connection_lifetime = None;
 
         for (k, v) in url.query_pairs() {
             match k.as_ref() {
@@ -186,6 +198,28 @@ impl MysqlUrl {
                         }
                     };
                 }
+                "max_connection_lifetime" => {
+                    let as_int = v
+                        .parse()
+                        .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
+
+                    if as_int == 0 {
+                        max_connection_lifetime = None;
+                    } else {
+                        max_connection_lifetime = Some(Duration::from_secs(as_int));
+                    }
+                }
+                "max_idle_connection_lifetime" => {
+                    let as_int = v
+                        .parse()
+                        .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
+
+                    if as_int == 0 {
+                        max_idle_connection_lifetime = None;
+                    } else {
+                        max_idle_connection_lifetime = Some(Duration::from_secs(as_int));
+                    }
+                }
                 _ => {
                     tracing::trace!(message = "Discarding connection string param", param = &*k);
                 }
@@ -200,6 +234,8 @@ impl MysqlUrl {
             connect_timeout,
             socket_timeout,
             pool_timeout,
+            max_connection_lifetime,
+            max_idle_connection_lifetime,
         })
     }
 
@@ -243,6 +279,8 @@ pub(crate) struct MysqlUrlQueryParams {
     socket_timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
     pool_timeout: Option<Duration>,
+    max_connection_lifetime: Option<Duration>,
+    max_idle_connection_lifetime: Option<Duration>,
 }
 
 impl Mysql {

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -265,7 +265,7 @@ impl PostgresUrl {
         let mut pg_bouncer = false;
         let mut statement_cache_size = 500;
         let mut max_connection_lifetime = None;
-        let mut max_idle_connection_lifetime = None;
+        let mut max_idle_connection_lifetime = Some(Duration::from_secs(300));
 
         for (k, v) in url.query_pairs() {
             match k.as_ref() {

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -232,6 +232,16 @@ impl PostgresUrl {
         self.query_params.socket_timeout
     }
 
+    /// The maximum connection lifetime
+    pub fn max_connection_lifetime(&self) -> Option<Duration> {
+        self.query_params.max_connection_lifetime
+    }
+
+    /// The maximum idle connection lifetime
+    pub fn max_idle_connection_lifetime(&self) -> Option<Duration> {
+        self.query_params.max_idle_connection_lifetime
+    }
+
     pub(crate) fn cache(&self) -> LruCache<String, Statement> {
         if self.query_params.pg_bouncer {
             LruCache::new(0)
@@ -254,6 +264,8 @@ impl PostgresUrl {
         let mut pool_timeout = Some(Duration::from_secs(10));
         let mut pg_bouncer = false;
         let mut statement_cache_size = 500;
+        let mut max_connection_lifetime = None;
+        let mut max_idle_connection_lifetime = None;
 
         for (k, v) in url.query_pairs() {
             match k.as_ref() {
@@ -344,6 +356,28 @@ impl PostgresUrl {
                         pool_timeout = Some(Duration::from_secs(as_int));
                     }
                 }
+                "max_connection_lifetime" => {
+                    let as_int = v
+                        .parse()
+                        .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
+
+                    if as_int == 0 {
+                        max_connection_lifetime = None;
+                    } else {
+                        max_connection_lifetime = Some(Duration::from_secs(as_int));
+                    }
+                }
+                "max_idle_connection_lifetime" => {
+                    let as_int = v
+                        .parse()
+                        .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
+
+                    if as_int == 0 {
+                        max_idle_connection_lifetime = None;
+                    } else {
+                        max_idle_connection_lifetime = Some(Duration::from_secs(as_int));
+                    }
+                }
                 _ => {
                     tracing::trace!(message = "Discarding connection string param", param = &*k);
                 }
@@ -366,6 +400,8 @@ impl PostgresUrl {
             socket_timeout,
             pg_bouncer,
             statement_cache_size,
+            max_connection_lifetime,
+            max_idle_connection_lifetime,
         })
     }
 
@@ -410,6 +446,8 @@ pub(crate) struct PostgresUrlQueryParams {
     connect_timeout: Option<Duration>,
     pool_timeout: Option<Duration>,
     statement_cache_size: usize,
+    max_connection_lifetime: Option<Duration>,
+    max_idle_connection_lifetime: Option<Duration>,
 }
 
 impl PostgreSql {

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -176,6 +176,7 @@ pub struct Builder {
     connection_limit: usize,
     max_idle: Option<u64>,
     max_idle_lifetime: Option<Duration>,
+    max_lifetime: Option<Duration>,
     health_check_interval: Option<Duration>,
     test_on_check_out: bool,
     connect_timeout: Option<Duration>,
@@ -193,6 +194,7 @@ impl Builder {
             connection_limit,
             max_idle: None,
             max_idle_lifetime: None,
+            max_lifetime: None,
             health_check_interval: None,
             test_on_check_out: false,
             connect_timeout: None,
@@ -249,6 +251,21 @@ impl Builder {
         self.pool_timeout = Some(pool_timeout);
     }
 
+    /// A time how long a connection can be kept in the pool before
+    /// replaced with a new one. The reconnect happens in the next
+    /// [`check_out`].
+    ///
+    /// - Defaults to not set, meaning connections are kept forever.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_lifetime` is zero.
+    ///
+    /// [`check_out`]: struct.Quaint.html#method.check_out
+    pub fn max_lifetime(&mut self, max_lifetime: Duration) {
+        self.max_lifetime = Some(max_lifetime);
+    }
+
     /// A time how long an idling connection can be kept in the pool before
     /// replaced with a new one. The reconnect happens in the next
     /// [`check_out`].
@@ -301,6 +318,7 @@ impl Builder {
             .max_open(self.connection_limit as u64)
             .max_idle(self.max_idle.unwrap_or(self.connection_limit as u64))
             .max_idle_lifetime(self.max_idle_lifetime)
+            .max_lifetime(self.max_lifetime)
             .get_timeout(None) // we handle timeouts here
             .health_check_interval(self.health_check_interval)
             .test_on_check_out(self.test_on_check_out)

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -187,13 +187,14 @@ impl Builder {
     fn new(url: &str, manager: QuaintManager) -> crate::Result<Self> {
         let connection_limit = num_cpus::get_physical() * 2 + 1;
         let connection_info = ConnectionInfo::from_url(url)?;
+        let max_idle_lifetime = Duration::from_secs(300)
 
         Ok(Self {
             manager,
             connection_info,
             connection_limit,
             max_idle: None,
-            max_idle_lifetime: None,
+            max_idle_lifetime,
             max_lifetime: None,
             health_check_interval: None,
             test_on_check_out: false,
@@ -270,7 +271,7 @@ impl Builder {
     /// replaced with a new one. The reconnect happens in the next
     /// [`check_out`].
     ///
-    /// - Defaults to not set, meaning idle connections are never reconnected.
+    /// - Defaults to 300 seconds
     ///
     /// # Panics
     ///

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -367,6 +367,14 @@ impl Quaint {
                     builder.connection_limit(limit);
                 }
 
+                if let Some(max_lifetime) = params.max_connection_lifetime {
+                    builder.max_lifetime(max_lifetime);
+                }
+
+                if let Some(max_idle_lifetime) = params.max_idle_connection_lifetime {
+                    builder.max_idle_lifetime(max_idle_lifetime);
+                }
+
                 Ok(builder)
             }
             #[cfg(feature = "mysql")]
@@ -374,6 +382,8 @@ impl Quaint {
                 let url = crate::connector::MysqlUrl::new(url::Url::parse(s)?)?;
                 let connection_limit = url.connection_limit();
                 let pool_timeout = url.pool_timeout();
+                let max_connection_lifetime = url.max_connection_lifetime();
+                let max_idle_connection_lifetime = url.max_idle_connection_lifetime();
 
                 let manager = QuaintManager::Mysql { url };
                 let mut builder = Builder::new(s, manager)?;
@@ -386,6 +396,14 @@ impl Quaint {
                     builder.pool_timeout(timeout);
                 }
 
+                if let Some(max_lifetime) = max_connection_lifetime {
+                    builder.max_lifetime(max_lifetime);
+                }
+
+                if let Some(max_idle_lifetime) = max_idle_connection_lifetime {
+                    builder.max_idle_lifetime(max_idle_lifetime);
+                }
+
                 Ok(builder)
             }
             #[cfg(feature = "postgresql")]
@@ -393,6 +411,8 @@ impl Quaint {
                 let url = crate::connector::PostgresUrl::new(url::Url::parse(s)?)?;
                 let connection_limit = url.connection_limit();
                 let pool_timeout = url.pool_timeout();
+                let max_connection_lifetime = url.max_connection_lifetime();
+                let max_idle_connection_lifetime = url.max_idle_connection_lifetime();
 
                 let manager = QuaintManager::Postgres { url };
                 let mut builder = Builder::new(s, manager)?;
@@ -405,6 +425,14 @@ impl Quaint {
                     builder.pool_timeout(timeout);
                 }
 
+                if let Some(max_lifetime) = max_connection_lifetime {
+                    builder.max_lifetime(max_lifetime);
+                }
+
+                if let Some(max_idle_lifetime) = max_idle_connection_lifetime {
+                    builder.max_idle_lifetime(max_idle_lifetime);
+                }
+
                 Ok(builder)
             }
             #[cfg(feature = "mssql")]
@@ -412,6 +440,8 @@ impl Quaint {
                 let url = crate::connector::MssqlUrl::new(s)?;
                 let connection_limit = url.connection_limit();
                 let pool_timeout = url.pool_timeout();
+                let max_connection_lifetime = url.max_connection_lifetime();
+                let max_idle_connection_lifetime = url.max_idle_connection_lifetime();
 
                 let manager = QuaintManager::Mssql { url };
                 let mut builder = Builder::new(s, manager)?;
@@ -422,6 +452,14 @@ impl Quaint {
 
                 if let Some(timeout) = pool_timeout {
                     builder.pool_timeout(timeout);
+                }
+
+                if let Some(max_lifetime) = max_connection_lifetime {
+                    builder.max_lifetime(max_lifetime);
+                }
+
+                if let Some(max_idle_lifetime) = max_idle_connection_lifetime {
+                    builder.max_idle_lifetime(max_idle_lifetime);
                 }
 
                 Ok(builder)

--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -187,14 +187,13 @@ impl Builder {
     fn new(url: &str, manager: QuaintManager) -> crate::Result<Self> {
         let connection_limit = num_cpus::get_physical() * 2 + 1;
         let connection_info = ConnectionInfo::from_url(url)?;
-        let max_idle_lifetime = Duration::from_secs(300)
 
         Ok(Self {
             manager,
             connection_info,
             connection_limit,
             max_idle: None,
-            max_idle_lifetime,
+            max_idle_lifetime: None,
             max_lifetime: None,
             health_check_interval: None,
             test_on_check_out: false,


### PR DESCRIPTION
This adds the `max_lifetime` on the builder and exposes `max_connection_lifetime` and `max_idle_connection_lifetime` via the URL parser.
Needed for serverless environments where it is not a good idea to never close connections, see https://github.com/prisma/prisma/issues/5977

I did try to respect the coding style of each parser but there is a refactoring job to be done down there to make them uniform, it's a bit of a mess. 