### PR TITLE
fix: bump mobc version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ tracing = { version = "0.1", optional = true }
 tracing-core = { version = "0.1", optional = true }
 bit-vec = { version = "0.6.1", optional = true }
 bytes = { version = "1.0", optional = true }
-mobc = { version = "0.7.0", optional = true }
+mobc = { version = "0.7.1", optional = true }
 serde = { version = "1.0", optional = true }
 connection-string = "0.1.10"
 tiberius = { version = "0.5.8", optional = true, features = ["sql-browser-tokio", "chrono", "bigdecimal"]}


### PR DESCRIPTION
This will add the FIFO queue in the connection requests and will solve a bug when requests are canceled.
Did extensive testing on that one.