### PR TITLE
Fix SQLite datetime conversion

### DIFF
--- a/src/connector/sqlite/conversion.rs
+++ b/src/connector/sqlite/conversion.rs
@@ -6,10 +6,14 @@ use crate::{
     },
     error::{Error, ErrorKind},
 };
+
 use rusqlite::{
     types::{Null, ToSql, ToSqlOutput, ValueRef},
     Column, Error as RusqlError, Row as SqliteRow, Rows as SqliteRows,
 };
+
+#[cfg(feature = "chrono")]
+use chrono::TimeZone;
 
 impl TypeIdentifier for Column<'_> {
     fn is_real(&self) -> bool {
@@ -157,10 +161,8 @@ impl<'a> GetRow for SqliteRow<'a> {
                     }
                     #[cfg(feature = "chrono")]
                     c if c.is_datetime() => {
-                        let sec = i / 1000;
-                        let ns = i % 1000 * 1_000_000;
-                        let dt = chrono::NaiveDateTime::from_timestamp(sec, ns as u32);
-                        Value::datetime(chrono::DateTime::from_utc(dt, chrono::Utc))
+                        let dt = chrono::Utc.timestamp_millis(i);
+                        Value::datetime(dt)
                     }
                     _ => Value::integer(i),
                 },


### PR DESCRIPTION
Rustqlite stores incoming dates like `1968-11-02T02:25:15.160Z` as millis (`-36711284840`), which fails the replaced conversion logic with all sorts of invalid datetime panics.

Proposed fix is to simply use the UTC timestamp conversion chrono offers, without additional computations in between.