### PR TITLE
Mark connection as unhealthy if closed

### DIFF
--- a/src/connector/mysql/error.rs
+++ b/src/connector/mysql/error.rs
@@ -10,6 +10,9 @@ impl From<my::Error> for Error {
                 message: err.to_string(),
             })
             .build(),
+            my::Error::Io(my::IoError::Io(err)) if err.kind() == std::io::ErrorKind::UnexpectedEof => {
+                Error::builder(ErrorKind::ConnectionClosed).build()
+            }
             my::Error::Io(io_error) => Error::builder(ErrorKind::ConnectionError(io_error.into())).build(),
             my::Error::Driver(e) => Error::builder(ErrorKind::QueryError(e.into())).build(),
             my::Error::Server(ServerError { ref message, code, .. }) if code == 1062 => {

--- a/src/connector/postgres/error.rs
+++ b/src/connector/postgres/error.rs
@@ -4,6 +4,10 @@ impl From<tokio_postgres::error::Error> for Error {
     fn from(e: tokio_postgres::error::Error) -> Error {
         use tokio_postgres::error::DbError;
 
+        if e.is_closed() {
+            return Error::builder(ErrorKind::ConnectionClosed).build();
+        }
+
         match e.code().map(|c| c.code()) {
             Some(code) if code == "22001" => {
                 let code = code.to_string();

--- a/src/connector/queryable.rs
+++ b/src/connector/queryable.rs
@@ -40,6 +40,9 @@ pub trait Queryable: Send + Sync {
     /// parsing or normalization.
     async fn version(&self) -> crate::Result<Option<String>>;
 
+    /// Returns false, if connection is considered to not be in a working state.
+    fn is_healthy(&self) -> bool;
+
     /// Execute a `SELECT` query.
     async fn select(&self, q: Select<'_>) -> crate::Result<ResultSet> {
         self.query(q.into()).await

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -218,6 +218,10 @@ impl Queryable for Sqlite {
     async fn version(&self) -> crate::Result<Option<String>> {
         Ok(Some(rusqlite::version().into()))
     }
+
+    fn is_healthy(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/src/connector/transaction.rs
+++ b/src/connector/transaction.rs
@@ -64,4 +64,8 @@ impl<'a> Queryable for Transaction<'a> {
     async fn version(&self) -> crate::Result<Option<String>> {
         self.inner.version().await
     }
+
+    fn is_healthy(&self) -> bool {
+        self.inner.is_healthy()
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,6 +124,11 @@ impl Error {
     pub fn kind(&self) -> &ErrorKind {
         &self.kind
     }
+
+    /// Determines if the error was associated with closed connection.
+    pub fn is_closed(&self) -> bool {
+        matches!(self.kind, ErrorKind::ConnectionClosed)
+    }
 }
 
 impl fmt::Display for Error {
@@ -196,6 +201,9 @@ pub enum ErrorKind {
 
     #[error("Timed out when connecting to the database.")]
     ConnectTimeout,
+
+    #[error("The server terminated the connection.")]
+    ConnectionClosed,
 
     #[error(
         "Timed out fetching a connection from the pool (connection limit: {}, in use: {})",

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -53,6 +53,10 @@ impl Queryable for PooledConnection {
     fn begin_statement(&self) -> &'static str {
         self.inner.begin_statement()
     }
+
+    fn is_healthy(&self) -> bool {
+        self.inner.is_healthy()
+    }
 }
 
 #[doc(hidden)]
@@ -114,6 +118,10 @@ impl Manager for QuaintManager {
     async fn check(&self, conn: Self::Connection) -> crate::Result<Self::Connection> {
         conn.raw_cmd("SELECT 1").await?;
         Ok(conn)
+    }
+
+    fn validate(&self, conn: &mut Self::Connection) -> bool {
+        conn.is_healthy()
     }
 }
 

--- a/src/single.rs
+++ b/src/single.rs
@@ -219,4 +219,8 @@ impl Queryable for Quaint {
     fn begin_statement(&self) -> &'static str {
         self.inner.begin_statement()
     }
+
+    fn is_healthy(&self) -> bool {
+        self.inner.is_healthy()
+    }
 }


### PR DESCRIPTION
The querying connection will error out as connection closed, then mark itself as dead and the pool will not give it back to anybody else.

Closes: https://github.com/prisma/quaint/issues/273