### PR TITLE
No need to write the table/alias in mysql inserts.

### DIFF
--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -136,7 +136,7 @@ impl<'a> Visitor<'a> for Mysql<'a> {
 
                     self.write(" (")?;
                     for (i, c) in insert.columns.into_iter().enumerate() {
-                        self.visit_column(c)?;
+                        self.visit_column(c.into_bare())?;
 
                         if i < (columns - 1) {
                             self.write(",")?;
@@ -156,7 +156,7 @@ impl<'a> Visitor<'a> for Mysql<'a> {
 
                 self.write(" (")?;
                 for (i, c) in insert.columns.into_iter().enumerate() {
-                    self.visit_column(c)?;
+                    self.visit_column(c.into_bare())?;
 
                     if i < (columns - 1) {
                         self.write(",")?;


### PR DESCRIPTION
In certain flavors of MySQL using fully qualified column names will just not work at all (such as in Vitess).