### PR TITLE
Better typing on OUTPUT for SQL Server

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -29,7 +29,7 @@ mod union;
 mod update;
 mod values;
 
-pub use column::{Column, DefaultValue, TypeFamily};
+pub use column::{Column, DefaultValue, TypeDataLength, TypeFamily};
 pub use compare::{Comparable, Compare};
 pub use conditions::ConditionTree;
 pub use conjunctive::Conjunctive;

--- a/src/ast/column.rs
+++ b/src/ast/column.rs
@@ -6,16 +6,22 @@ use crate::{
 use std::borrow::Cow;
 
 #[derive(Debug, Clone, Copy)]
+pub enum TypeDataLength {
+    Constant(u16),
+    Maximum,
+}
+
+#[derive(Debug, Clone, Copy)]
 pub enum TypeFamily {
-    Text,
+    Text(Option<TypeDataLength>),
     Int,
     Float,
     Double,
     Boolean,
     Uuid,
     DateTime,
-    Decimal,
-    Bytes,
+    Decimal(Option<(u8, u8)>),
+    Bytes(Option<TypeDataLength>),
 }
 
 /// A column definition.

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -628,6 +628,120 @@ async fn returning_insert(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "mssql", feature = "bigdecimal"))]
+#[test_each_connector(tags("mssql"))]
+async fn returning_decimal_insert_with_type_defs(api: &mut dyn TestApi) -> crate::Result<()> {
+    use bigdecimal::BigDecimal;
+    use std::str::FromStr;
+
+    let dec = BigDecimal::from_str("17661757261711787211853")?;
+    let table = api.create_table("id int, val numeric(26,0)").await?;
+    let col = Column::from("val").type_family(TypeFamily::Decimal(Some((26, 0))));
+
+    let insert = Insert::single_into(&table).value("id", 2).value(col, dec.clone());
+
+    let res = api
+        .conn()
+        .insert(Insert::from(insert).returning(vec!["id", "val"]))
+        .await?;
+
+    assert_eq!(1, res.len());
+
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(2), row["id"].as_i64());
+    assert_eq!(Some(&dec), row["val"].as_numeric());
+
+    Ok(())
+}
+
+#[cfg(feature = "mssql")]
+#[test_each_connector(tags("mssql"))]
+async fn returning_constant_nvarchar_insert_with_type_defs(api: &mut dyn TestApi) -> crate::Result<()> {
+    let table = api.create_table("id int, val nvarchar(4000)").await?;
+    let col = Column::from("val").type_family(TypeFamily::Text(Some(TypeDataLength::Constant(4000))));
+
+    let insert = Insert::single_into(&table).value("id", 2).value(col, "meowmeow");
+
+    let res = api
+        .conn()
+        .insert(Insert::from(insert).returning(vec!["id", "val"]))
+        .await?;
+
+    assert_eq!(1, res.len());
+
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(2), row["id"].as_i64());
+    assert_eq!(Some("meowmeow"), row["val"].as_str());
+
+    Ok(())
+}
+
+#[cfg(feature = "mssql")]
+#[test_each_connector(tags("mssql"))]
+async fn returning_max_nvarchar_insert_with_type_defs(api: &mut dyn TestApi) -> crate::Result<()> {
+    let table = api.create_table("id int, val nvarchar(max)").await?;
+    let col = Column::from("val").type_family(TypeFamily::Text(Some(TypeDataLength::Maximum)));
+
+    let insert = Insert::single_into(&table).value("id", 2).value(col, "meowmeow");
+
+    let res = api
+        .conn()
+        .insert(Insert::from(insert).returning(vec!["id", "val"]))
+        .await?;
+
+    assert_eq!(1, res.len());
+
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(2), row["id"].as_i64());
+    assert_eq!(Some("meowmeow"), row["val"].as_str());
+
+    Ok(())
+}
+
+#[cfg(feature = "mssql")]
+#[test_each_connector(tags("mssql"))]
+async fn returning_constant_varchar_insert_with_type_defs(api: &mut dyn TestApi) -> crate::Result<()> {
+    let table = api.create_table("id int, val varchar(4000)").await?;
+    let col = Column::from("val").type_family(TypeFamily::Text(Some(TypeDataLength::Constant(4000))));
+
+    let insert = Insert::single_into(&table).value("id", 2).value(col, "meowmeow");
+
+    let res = api
+        .conn()
+        .insert(Insert::from(insert).returning(vec!["id", "val"]))
+        .await?;
+
+    assert_eq!(1, res.len());
+
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(2), row["id"].as_i64());
+    assert_eq!(Some("meowmeow"), row["val"].as_str());
+
+    Ok(())
+}
+
+#[cfg(feature = "mssql")]
+#[test_each_connector(tags("mssql"))]
+async fn returning_max_varchar_insert_with_type_defs(api: &mut dyn TestApi) -> crate::Result<()> {
+    let table = api.create_table("id int, val varchar(max)").await?;
+    let col = Column::from("val").type_family(TypeFamily::Text(Some(TypeDataLength::Maximum)));
+
+    let insert = Insert::single_into(&table).value("id", 2).value(col, "meowmeow");
+
+    let res = api
+        .conn()
+        .insert(Insert::from(insert).returning(vec!["id", "val"]))
+        .await?;
+
+    assert_eq!(1, res.len());
+
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(2), row["id"].as_i64());
+    assert_eq!(Some("meowmeow"), row["val"].as_str());
+
+    Ok(())
+}
+
 #[cfg(feature = "mssql")]
 #[test_each_connector(tags("mssql"))]
 async fn multiple_resultset_should_return_the_last_one(api: &mut dyn TestApi) -> crate::Result<()> {


### PR DESCRIPTION
When using the `OUTPUT` on SQL Server `INSERT`, with triggers, the trick with return list should be typed correctly. Originally we just assumed the types close enough, but of course miscalculated certain exceptions. E.g. `decimal` was always `decimal(32,16)`, which would not fit `decimal(26,0)`...

Here we extend the type hints to the column with optional parameters.

Part of https://github.com/prisma/prisma/issues/5950