### PR TITLE
feat: add COALESCE function

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -1,5 +1,6 @@
 mod aggregate_to_string;
 mod average;
+mod coalesce;
 mod count;
 mod lower;
 mod maximum;
@@ -12,6 +13,7 @@ mod upper;
 
 pub use aggregate_to_string::*;
 pub use average::*;
+pub use coalesce::*;
 pub use count::*;
 pub use lower::*;
 pub use maximum::*;
@@ -46,6 +48,7 @@ pub(crate) enum FunctionType<'a> {
     Upper(Upper<'a>),
     Minimum(Minimum<'a>),
     Maximum(Maximum<'a>),
+    Coalesce(Coalesce<'a>),
 }
 
 impl<'a> Aliasable<'a> for Function<'a> {
@@ -72,5 +75,6 @@ function!(
     Lower,
     Upper,
     Minimum,
-    Maximum
+    Maximum,
+    Coalesce
 );

--- a/src/ast/function/coalesce.rs
+++ b/src/ast/function/coalesce.rs
@@ -1,0 +1,36 @@
+use super::Function;
+use crate::ast::Expression;
+
+#[derive(Debug, Clone, PartialEq)]
+/// Returns the first non-null expression
+pub struct Coalesce<'a> {
+    pub(crate) exprs: Vec<Expression<'a>>,
+}
+
+/// Returns the first non-null argument
+///
+/// ```rust
+/// # use quaint::{ast::*, visitor::{Visitor, Sqlite}};
+/// # fn main() -> Result<(), quaint::error::Error> {
+/// let exprs: Vec<Expression> = vec![
+///   Column::from(("users", "company")).into(),
+///   Value::text("Individual").into(),
+/// ];
+/// let query = Select::from_table("users").value(coalesce(exprs));
+/// let (sql, params) = Sqlite::build(query)?;
+/// assert_eq!("SELECT COALESCE(`users`.`company`, ?) FROM `users`", sql);
+/// assert_eq!(vec![Value::text("Individual")], params);
+/// # Ok(())
+/// # }
+/// ```
+pub fn coalesce<'a, T, V>(exprs: V) -> Function<'a>
+where
+    T: Into<Expression<'a>>,
+    V: Into<Vec<T>>,
+{
+    let fun = Coalesce {
+        exprs: exprs.into().into_iter().map(|e| e.into()).collect(),
+    };
+
+    fun.into()
+}

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -1951,6 +1951,8 @@ async fn coalesce_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     let row = api.conn().select(select).await?.into_single()?;
 
     assert_eq!(Some("Individual"), row["val"].as_str());
+
+    Ok(())
 }
 
 #[cfg(all(feature = "json", feature = "mysql"))]

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -1941,3 +1941,14 @@ async fn bigdecimal_read_write_to_floating(api: &mut dyn TestApi) -> crate::Resu
 
     Ok(())
 }
+
+#[test_each_connector]
+async fn coalesce_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    let exprs: Vec<Expression> = vec![Value::Text(None).into(), Value::text("Individual").into()];
+    let select = Select::default().value(coalesce(exprs).alias("val"));
+    let row = api.conn().select(select).await?.into_single()?;
+
+    assert_eq!(Some("Individual"), row["val"].as_str());
+
+    Ok(())
+}

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -949,6 +949,20 @@ pub trait Visitor<'a> {
                 self.write("MAX")?;
                 self.surround_with("(", ")", |ref mut s| s.visit_column(max.column))?;
             }
+            FunctionType::Coalesce(coalesce) => {
+                self.write("COALESCE")?;
+                self.surround_with("(", ")", |s| {
+                    let len = coalesce.exprs.len();
+                    for (index, expr) in coalesce.exprs.into_iter().enumerate() {
+                        s.visit_expression(expr)?;
+                        if index < len - 1 {
+                            s.write(", ")?;
+                        }
+                    }
+
+                    Ok(())
+                })?;
+            }
         };
 
         if let Some(alias) = fun.alias {


### PR DESCRIPTION
## Overview

Adds `COALESCE(param1, ...paramN)` function. Supported by all drivers.