### PR TITLE
fix: json_extract ::jsonb casting with equality

### DIFF
--- a/src/ast/function/json_extract.rs
+++ b/src/ast/function/json_extract.rs
@@ -51,7 +51,7 @@ impl<'a> JsonPath<'a> {
 /// let extract: Expression = json_extract(Column::from(("users", "json")), JsonPath::array(["a", "b"]), false).into();
 /// let query = Select::from_table("users").so_that(extract.equals("c"));
 /// let (sql, params) = Postgres::build(query)?;
-/// assert_eq!("SELECT \"users\".* FROM \"users\" WHERE \"users\".\"json\"#>ARRAY[$1, $2]::text[] = $3", sql);
+/// assert_eq!("SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"json\"#>ARRAY[$1, $2]::text[]) = $3", sql);
 /// assert_eq!(vec![Value::text("a"), Value::text("b"), Value::text("c")], params);
 /// # Ok(())
 /// # }

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2016,6 +2016,12 @@ async fn json_extract_array_path_fun(api: &mut dyn TestApi) -> crate::Result<()>
     let row = api.conn().select(select).await?.into_single()?;
     assert_eq!(Some(&serde_json::json!({ "a": { "b": "c" } })), row["obj"].as_json());
 
+    // Test equality with Json value
+    let extract: Expression = json_extract(col!("obj"), JsonPath::array(["a", "b"]), false).into();
+    let select = Select::from_table(&table).so_that(extract.equals(serde_json::Value::String("c".to_owned())));
+    let row = api.conn().select(select).await?.into_single()?;
+    assert_eq!(Some(&serde_json::json!({ "a": { "b": "c" } })), row["obj"].as_json());
+
     // Test array index extraction
     let extract: Expression = json_extract(col!("obj"), JsonPath::array(["a", "b", "1"]), false).into();
     let select = Select::from_table(&table).so_that(extract.equals("2"));

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -269,6 +269,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
             #[cfg(feature = "mysql")]
             JsonPath::String(_) => panic!("JSON path string notation is not supported for Postgres"),
             JsonPath::Array(json_path) => {
+                self.write("(")?;
                 self.visit_expression(*json_extract.column)?;
 
                 if json_extract.extract_as_string {
@@ -289,7 +290,8 @@ impl<'a> Visitor<'a> for Postgres<'a> {
                         }
                     }
                     Ok(())
-                })
+                })?;
+                self.write(")")
             }
         }
     }


### PR DESCRIPTION
## Overview

With postgres, when rendering an `equals`, if the right value is a Json value, the left value gets casted to a `::jsonb`.

This was causing issues with `json_extract` because it's rendered as such: `col#>ARRAY['a','b']::text`.

Appending `::jsonb` to `col#>ARRAY['a','b']::text`, was causing an error. This fix adds parenthesis around `col#>ARRAY['a','b']::text` so that the whole expression properly gets casted as `(col#>ARRAY['a','b']::text)::jsonb`.

A regression test was also added.