### PR TITLE
Optionally expose postgres driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ features = ["docs", "all"]
 [features]
 default = []
 docs = []
+# Expose the underlying database drivers when a connector is enabled. This is a
+# way to access database-specific methods when you need extra control.
+expose-drivers = []
 
 all = [
   "chrono",

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -26,6 +26,11 @@ use url::Url;
 
 pub(crate) const DEFAULT_SCHEMA: &str = "public";
 
+/// The underlying postgres driver. Only available with the `expose-drivers`
+/// Cargo feature.
+#[cfg(feature = "expose-drivers")]
+pub use tokio_postgres;
+
 #[derive(Clone)]
 struct Hidden<T>(T);
 
@@ -508,6 +513,14 @@ impl PostgreSql {
             statement_cache: Mutex::new(url.cache()),
             is_healthy: AtomicBool::new(true),
         })
+    }
+
+    /// The underlying tokio_postgres::Client. Only available with the
+    /// `expose-drivers` Cargo feature. This is a lower level API when you need
+    /// to get into database specific features.
+    #[cfg(feature = "expose-drivers")]
+    pub fn client(&self) -> &tokio_postgres::Client {
+        &self.client.0
     }
 
     #[tracing::instrument(skip(self))]


### PR DESCRIPTION
This lets us drop down to a lower level API when we need to, at little
maintenance cost. The main use case for this in the Prisma Migration
Engine is to access the full error objects.

I want to extend this to other connectors if this pans out as expected
on postgres.