### PR TITLE
fix(logging): Clearer wording about connection pool size

### DIFF
--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -316,7 +316,7 @@ impl Builder {
         let pg_bouncer = if info.pg_bouncer() { " in PgBouncer mode" } else { "" };
 
         tracing::info!(
-            "Starting a {} pool with {} connections{}.",
+            "Starting a {} pool for maximum {} connections{}.",
             family,
             connection_limit,
             pg_bouncer


### PR DESCRIPTION
Although the current wording is technically 100% correct, users are sometimes slightly confused and think that the pool is started with all these connections already open. This is of course not the case, so this a bit more defensive wording hopefully avoids that confusion.