### PR TITLE
feat(postgres): support full-text search on Postgres

### DIFF
--- a/src/ast/compare.rs
+++ b/src/ast/compare.rs
@@ -48,7 +48,7 @@ pub enum Compare<'a> {
     #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
     JsonCompare(JsonCompare<'a>),
     // `left AGAINST (right)
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     Matches(Box<Expression<'a>>, Cow<'a, str>),
 }
 
@@ -785,7 +785,7 @@ pub trait Comparable<'a> {
     /// # Ok(())    
     /// # }
     /// ```
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn matches<T>(self, query: T) -> Compare<'a>
     where
         T: Into<Cow<'a, str>>;
@@ -1066,7 +1066,7 @@ where
         val.json_type_equals(json_type)
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn matches<T>(self, query: T) -> Compare<'a>
     where
         T: Into<Cow<'a, str>>,

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -488,4 +488,12 @@ impl<'a> Comparable<'a> for Expression<'a> {
     {
         Compare::JsonCompare(JsonCompare::TypeEquals(Box::new(self), json_type.into()))
     }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn matches<T>(self, query: T) -> Compare<'a>
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        Compare::Matches(Box::new(self), query.into())
+    }
 }

--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -489,7 +489,7 @@ impl<'a> Comparable<'a> for Expression<'a> {
         Compare::JsonCompare(JsonCompare::TypeEquals(Box::new(self), json_type.into()))
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn matches<T>(self, query: T) -> Compare<'a>
     where
         T: Into<Cow<'a, str>>,

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -10,6 +10,8 @@ mod minimum;
 mod row_number;
 #[cfg(all(feature = "json", feature = "postgresql"))]
 mod row_to_json;
+#[cfg(any(feature = "postgresql", feature = "mysql"))]
+mod search;
 mod sum;
 mod upper;
 
@@ -25,6 +27,8 @@ pub use minimum::*;
 pub use row_number::*;
 #[cfg(all(feature = "json", feature = "postgresql"))]
 pub use row_to_json::*;
+#[cfg(any(feature = "postgresql", feature = "mysql"))]
+pub use search::*;
 pub use sum::*;
 pub use upper::*;
 
@@ -55,6 +59,8 @@ pub(crate) enum FunctionType<'a> {
     Coalesce(Coalesce<'a>),
     #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
     JsonExtract(JsonExtract<'a>),
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    TextSearch(TextSearch<'a>),
 }
 
 impl<'a> Aliasable<'a> for Function<'a> {
@@ -74,6 +80,9 @@ function!(RowToJson);
 
 #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 function!(JsonExtract);
+
+#[cfg(any(feature = "postgresql", feature = "mysql"))]
+function!(TextSearch);
 
 function!(
     RowNumber,

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -10,7 +10,7 @@ mod minimum;
 mod row_number;
 #[cfg(all(feature = "json", feature = "postgresql"))]
 mod row_to_json;
-#[cfg(any(feature = "postgresql", feature = "mysql"))]
+#[cfg(feature = "postgresql")]
 mod search;
 mod sum;
 mod upper;
@@ -27,7 +27,7 @@ pub use minimum::*;
 pub use row_number::*;
 #[cfg(all(feature = "json", feature = "postgresql"))]
 pub use row_to_json::*;
-#[cfg(any(feature = "postgresql", feature = "mysql"))]
+#[cfg(feature = "postgresql")]
 pub use search::*;
 pub use sum::*;
 pub use upper::*;
@@ -59,7 +59,7 @@ pub(crate) enum FunctionType<'a> {
     Coalesce(Coalesce<'a>),
     #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
     JsonExtract(JsonExtract<'a>),
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     TextSearch(TextSearch<'a>),
 }
 
@@ -81,7 +81,7 @@ function!(RowToJson);
 #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 function!(JsonExtract);
 
-#[cfg(any(feature = "postgresql", feature = "mysql"))]
+#[cfg(feature = "postgresql")]
 function!(TextSearch);
 
 function!(

--- a/src/ast/function/search.rs
+++ b/src/ast/function/search.rs
@@ -19,7 +19,7 @@ pub struct TextSearch<'a> {
 /// # Ok(())    
 /// # }
 /// ```
-#[cfg(any(feature = "postgresql", feature = "mysql"))]
+#[cfg(feature = "postgresql")]
 pub fn text_search<'a, T: Clone>(columns: &[T]) -> super::Function<'a>
 where
     T: Into<Column<'a>>,

--- a/src/ast/function/search.rs
+++ b/src/ast/function/search.rs
@@ -1,0 +1,31 @@
+use crate::prelude::Column;
+
+#[derive(Debug, Clone, PartialEq)]
+/// Holds the columns on which to perform a full-text search
+pub struct TextSearch<'a> {
+    pub(crate) columns: Vec<Column<'a>>,
+}
+
+/// Performs a full-text search. Use it in combination with the `.matches()` comparable.
+///
+/// ```rust
+/// # use quaint::{ast::*, visitor::{Visitor, Postgres}};
+/// # fn main() -> Result<(), quaint::error::Error> {
+/// let search: Expression = text_search(&vec![Column::from("name"), Column::from("ingredients")]).into();
+/// let query = Select::from_table("recipes").so_that(search.matches("chicken"));
+/// let (sql, params) = Postgres::build(query)?;
+/// assert_eq!("SELECT \"recipes\".* FROM \"recipes\" WHERE to_tsvector(\"name\"|| ' ' ||\"ingredients\") @@ to_tsquery($1)", sql);
+/// assert_eq!(params, vec![Value::from("chicken")]);
+/// # Ok(())    
+/// # }
+/// ```
+#[cfg(any(feature = "postgresql", feature = "mysql"))]
+pub fn text_search<'a, T: Clone>(columns: &[T]) -> super::Function<'a>
+where
+    T: Into<Column<'a>>,
+{
+    let columns: Vec<Column> = columns.iter().map(|c| c.clone().into()).collect();
+    let fun = TextSearch { columns };
+
+    fun.into()
+}

--- a/src/ast/function/search.rs
+++ b/src/ast/function/search.rs
@@ -11,10 +11,15 @@ pub struct TextSearch<'a> {
 /// ```rust
 /// # use quaint::{ast::*, visitor::{Visitor, Postgres}};
 /// # fn main() -> Result<(), quaint::error::Error> {
-/// let search: Expression = text_search(&vec![Column::from("name"), Column::from("ingredients")]).into();
+/// let search: Expression = text_search(&[Column::from("name"), Column::from("ingredients")]).into();
 /// let query = Select::from_table("recipes").so_that(search.matches("chicken"));
 /// let (sql, params) = Postgres::build(query)?;
-/// assert_eq!("SELECT \"recipes\".* FROM \"recipes\" WHERE to_tsvector(\"name\"|| ' ' ||\"ingredients\") @@ to_tsquery($1)", sql);
+///
+/// assert_eq!(
+///    "SELECT \"recipes\".* FROM \"recipes\" \
+///     WHERE to_tsvector(\"name\"|| ' ' ||\"ingredients\") @@ to_tsquery($1)", sql
+/// );
+///
 /// assert_eq!(params, vec![Value::from("chicken")]);
 /// # Ok(())    
 /// # }

--- a/src/ast/row.rs
+++ b/src/ast/row.rs
@@ -384,4 +384,14 @@ impl<'a> Comparable<'a> for Row<'a> {
 
         value.json_type_equals(json_type)
     }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn matches<T>(self, query: T) -> Compare<'a>
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        let value: Expression<'a> = self.into();
+
+        value.matches(query)
+    }
 }

--- a/src/ast/row.rs
+++ b/src/ast/row.rs
@@ -385,7 +385,7 @@ impl<'a> Comparable<'a> for Row<'a> {
         value.json_type_equals(json_type)
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn matches<T>(self, query: T) -> Compare<'a>
     where
         T: Into<Cow<'a, str>>,

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2497,6 +2497,45 @@ async fn json_gt_gte_lt_lte_fun(api: &mut dyn TestApi) -> crate::Result<()> {
         res.get(2).unwrap()["json"].as_json()
     );
     assert_eq!(None, res.get(3));
+}
+
+// TODO: Figure out a way to test MySQL. We can't create FULLTEXT indexes on temporary InnoDB tables.
+#[cfg(any(feature = "postgresql", feature = "mysql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn text_search_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    let table = api.create_table("name varchar(255), ingredients varchar(255)").await?;
+
+    let insert_1 = Insert::single_into(&table)
+        .value("name", "Chicken Curry")
+        .value("ingredients", "Chicken, Curry, Rice");
+    let insert_2 = Insert::single_into(&table)
+        .value("name", "Caesar Salad")
+        .value("ingredients", "Salad, Chicken, Parmesan, Caesar Sauce");
+    api.conn().insert(insert_1.into()).await?;
+    api.conn().insert(insert_2.into()).await?;
+
+    // Search on multiple columns at the same time
+    let search: Expression = text_search(&vec!["name", "ingredients"]).into();
+    let q = Select::from_table(&table).so_that(search.matches("chicken"));
+    let res = api.conn().select(q).await?;
+    let row_one = res.get(0).unwrap();
+    let row_two = res.get(1).unwrap();
+
+    assert_eq!(row_one["name"], Value::from("Chicken Curry"));
+    assert_eq!(row_one["ingredients"], Value::from("Chicken, Curry, Rice"));
+    assert_eq!(row_two["name"], Value::from("Caesar Salad"));
+    assert_eq!(
+        row_two["ingredients"],
+        Value::from("Salad, Chicken, Parmesan, Caesar Sauce")
+    );
+
+    // Search on a single column
+    let search: Expression = text_search(&vec!["name"]).into();
+    let q = Select::from_table(&table).so_that(search.matches("chicken"));
+    let row = api.conn().select(q).await?.into_single()?;
+
+    assert_eq!(row["name"], Value::from("Chicken Curry"));
+    assert_eq!(row["ingredients"], Value::from("Chicken, Curry, Rice"));
 
     Ok(())
 }

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2497,6 +2497,8 @@ async fn json_gt_gte_lt_lte_fun(api: &mut dyn TestApi) -> crate::Result<()> {
         res.get(2).unwrap()["json"].as_json()
     );
     assert_eq!(None, res.get(3));
+
+    Ok(())
 }
 
 // TODO: Figure out a way to test MySQL. We can't create FULLTEXT indexes on temporary InnoDB tables.

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2501,8 +2501,7 @@ async fn json_gt_gte_lt_lte_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
-// TODO: Figure out a way to test MySQL. We can't create FULLTEXT indexes on temporary InnoDB tables.
-#[cfg(any(feature = "postgresql", feature = "mysql"))]
+#[cfg(feature = "postgresql")]
 #[test_each_connector(tags("postgresql"))]
 async fn text_search_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     let table = api.create_table("name varchar(255), ingredients varchar(255)").await?;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -117,10 +117,10 @@ pub trait Visitor<'a> {
     #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
     fn visit_json_type_equals(&mut self, left: Expression<'a>, json_type: JsonType) -> Result;
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_text_search(&mut self, text_search: TextSearch<'a>) -> Result;
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>) -> Result;
 
     /// A visit to a value we parameterize
@@ -878,7 +878,7 @@ pub trait Visitor<'a> {
                 JsonCompare::ArrayNotEndsInto(left, right) => self.visit_json_array_ends_into(*left, *right, true),
                 JsonCompare::TypeEquals(left, json_type) => self.visit_json_type_equals(*left, json_type),
             },
-            #[cfg(any(feature = "postgresql", feature = "mysql"))]
+            #[cfg(feature = "postgresql")]
             Compare::Matches(left, right) => self.visit_matches(*left, right),
         }
     }
@@ -998,7 +998,7 @@ pub trait Visitor<'a> {
             FunctionType::JsonExtract(json_extract) => {
                 self.visit_json_extract(json_extract)?;
             }
-            #[cfg(any(feature = "postgresql", feature = "mysql"))]
+            #[cfg(feature = "postgresql")]
             FunctionType::TextSearch(text_search) => {
                 self.visit_text_search(text_search)?;
             }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -117,6 +117,12 @@ pub trait Visitor<'a> {
     #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
     fn visit_json_type_equals(&mut self, left: Expression<'a>, json_type: JsonType) -> Result;
 
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_text_search(&mut self, text_search: TextSearch<'a>) -> Result;
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>) -> Result;
+
     /// A visit to a value we parameterize
     fn visit_parameterized(&mut self, value: Value<'a>) -> Result {
         self.add_parameter(value);
@@ -872,6 +878,8 @@ pub trait Visitor<'a> {
                 JsonCompare::ArrayNotEndsInto(left, right) => self.visit_json_array_ends_into(*left, *right, true),
                 JsonCompare::TypeEquals(left, json_type) => self.visit_json_type_equals(*left, json_type),
             },
+            #[cfg(any(feature = "postgresql", feature = "mysql"))]
+            Compare::Matches(left, right) => self.visit_matches(*left, right),
         }
     }
 
@@ -984,21 +992,15 @@ pub trait Visitor<'a> {
             }
             FunctionType::Coalesce(coalesce) => {
                 self.write("COALESCE")?;
-                self.surround_with("(", ")", |s| {
-                    let len = coalesce.exprs.len();
-                    for (index, expr) in coalesce.exprs.into_iter().enumerate() {
-                        s.visit_expression(expr)?;
-                        if index < len - 1 {
-                            s.write(", ")?;
-                        }
-                    }
-
-                    Ok(())
-                })?;
+                self.surround_with("(", ")", |s| s.visit_columns(coalesce.exprs))?;
             }
             #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
             FunctionType::JsonExtract(json_extract) => {
                 self.visit_json_extract(json_extract)?;
+            }
+            #[cfg(any(feature = "postgresql", feature = "mysql"))]
+            FunctionType::TextSearch(text_search) => {
+                self.visit_text_search(text_search)?;
             }
         };
 

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -620,12 +620,12 @@ impl<'a> Visitor<'a> for Mssql<'a> {
         unimplemented!("JSON_TYPE is not yet supported on MSSQL")
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_text_search(&mut self, _text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on MSSQL")
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_matches(&mut self, _left: Expression<'a>, _right: std::borrow::Cow<'a, str>) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on MSSQL")
     }

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -619,6 +619,16 @@ impl<'a> Visitor<'a> for Mssql<'a> {
     fn visit_json_type_equals(&mut self, _left: Expression<'a>, _json_type: JsonType) -> visitor::Result {
         unimplemented!("JSON_TYPE is not yet supported on MSSQL")
     }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_text_search(&mut self, _text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
+        unimplemented!("Full-text search is not yet supported on MSSQL")
+    }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_matches(&mut self, _left: Expression<'a>, _right: std::borrow::Cow<'a, str>) -> visitor::Result {
+        unimplemented!("Full-text search is not yet supported on MSSQL")
+    }
 }
 
 #[cfg(test)]

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -456,12 +456,12 @@ impl<'a> Visitor<'a> for Mysql<'a> {
     }
 
     #[cfg(feature = "postgresql")]
-    fn visit_text_search(&mut self, text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
+    fn visit_text_search(&mut self, _text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on MySQL")
     }
 
     #[cfg(feature = "postgresql")]
-    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>) -> visitor::Result {
+    fn visit_matches(&mut self, _left: Expression<'a>, _right: std::borrow::Cow<'a, str>) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on MySQL")
     }
 }

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -455,28 +455,14 @@ impl<'a> Visitor<'a> for Mysql<'a> {
         Ok(())
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_text_search(&mut self, text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
-        let len = text_search.columns.len();
-        self.surround_with("MATCH(", ")", |s| {
-            for (i, column) in text_search.columns.into_iter().enumerate() {
-                s.visit_column(column)?;
-
-                if i < (len - 1) {
-                    s.write(", ")?;
-                }
-            }
-
-            Ok(())
-        })
+        unimplemented!("Full-text search is not yet supported on MySQL")
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>) -> visitor::Result {
-        self.visit_expression(left)?;
-        self.surround_with("AGAINST(", " IN NATURAL LANGUAGE MODE)", |s| {
-            s.visit_parameterized(Value::text(right))
-        })
+        unimplemented!("Full-text search is not yet supported on MySQL")
     }
 }
 

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -454,6 +454,30 @@ impl<'a> Visitor<'a> for Mysql<'a> {
 
         Ok(())
     }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_text_search(&mut self, text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
+        let len = text_search.columns.len();
+        self.surround_with("MATCH(", ")", |s| {
+            for (i, column) in text_search.columns.into_iter().enumerate() {
+                s.visit_column(column)?;
+
+                if i < (len - 1) {
+                    s.write(", ")?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>) -> visitor::Result {
+        self.visit_expression(left)?;
+        self.surround_with("AGAINST(", " IN NATURAL LANGUAGE MODE)", |s| {
+            s.visit_parameterized(Value::text(right))
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -374,7 +374,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         }
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_text_search(&mut self, text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
         let len = text_search.columns.len();
         self.surround_with("to_tsvector(", ")", |s| {
@@ -390,7 +390,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         })
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>) -> visitor::Result {
         self.visit_expression(left)?;
         self.write(" @@ ")?;

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -373,6 +373,29 @@ impl<'a> Visitor<'a> for Postgres<'a> {
             JsonType::Null => self.visit_expression(Value::text("null").into()),
         }
     }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_text_search(&mut self, text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
+        let len = text_search.columns.len();
+        self.surround_with("to_tsvector(", ")", |s| {
+            for (i, column) in text_search.columns.into_iter().enumerate() {
+                s.visit_column(column)?;
+
+                if i < (len - 1) {
+                    s.write("|| ' ' ||")?;
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>) -> visitor::Result {
+        self.visit_expression(left)?;
+        self.write(" @@ ")?;
+        self.surround_with("to_tsquery(", ")", |s| s.visit_parameterized(Value::text(right)))
+    }
 }
 
 #[cfg(test)]

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -270,6 +270,16 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
     fn visit_json_type_equals(&mut self, _left: Expression<'a>, _json_type: JsonType) -> visitor::Result {
         unimplemented!("JSON_TYPE is not yet supported on SQLite")
     }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_text_search(&mut self, _text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
+        unimplemented!("Full-text search is not yet supported on SQLite")
+    }
+
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_matches(&mut self, _left: Expression<'a>, _right: std::borrow::Cow<'a, str>) -> visitor::Result {
+        unimplemented!("Full-text search is not yet supported on SQLite")
+    }
 }
 
 #[cfg(test)]

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -271,12 +271,12 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
         unimplemented!("JSON_TYPE is not yet supported on SQLite")
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_text_search(&mut self, _text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on SQLite")
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    #[cfg(feature = "postgresql")]
     fn visit_matches(&mut self, _left: Expression<'a>, _right: std::borrow::Cow<'a, str>) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on SQLite")
     }


### PR DESCRIPTION
## Overview

Adds `text_search()` function and `.matches()` comparable to support full-text search on Postgres. Check out rustdocs to see the usages.