### PR TITLE
fix(mysql): json numeric comparisons on both sides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .direnv/
+.vscode/

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -410,76 +410,84 @@ impl<'a> Visitor<'a> for Mysql<'a> {
     }
 
     fn visit_greater_than(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        let compares_json = left.is_json_extract_fun() && right.is_json_value();
+        let compares_json_left = left.is_json_value() && right.is_json_extract_fun();
+        let compares_json_right = left.is_json_extract_fun() && right.is_json_value();
 
-        self.visit_expression(left)?;
-        self.write(" > ")?;
-
-        if compares_json {
-            self.write("CAST(")?;
+        if compares_json_left {
+            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
+        } else {
+            self.visit_expression(left)?;
         }
 
-        self.visit_expression(right)?;
+        self.write(" > ")?;
 
-        if compares_json {
-            self.write(" AS JSON)")?;
+        if compares_json_right {
+            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
+        } else {
+            self.visit_expression(right)?;
         }
 
         Ok(())
     }
 
     fn visit_greater_than_or_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        let compares_json = left.is_json_extract_fun() && right.is_json_value();
+        let compares_json_left = left.is_json_value() && right.is_json_extract_fun();
+        let compares_json_right = left.is_json_extract_fun() && right.is_json_value();
 
-        self.visit_expression(left)?;
-        self.write(" >= ")?;
-
-        if compares_json {
-            self.write("CAST(")?;
+        if compares_json_left {
+            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
+        } else {
+            self.visit_expression(left)?;
         }
 
-        self.visit_expression(right)?;
+        self.write(" >= ")?;
 
-        if compares_json {
-            self.write(" AS JSON)")?;
+        if compares_json_right {
+            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
+        } else {
+            self.visit_expression(right)?;
         }
 
         Ok(())
     }
 
     fn visit_less_than(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        let compares_json = left.is_json_extract_fun() && right.is_json_value();
+        let compares_json_left = left.is_json_value() && right.is_json_extract_fun();
+        let compares_json_right = left.is_json_extract_fun() && right.is_json_value();
 
-        self.visit_expression(left)?;
-        self.write(" < ")?;
-
-        if compares_json {
-            self.write("CAST(")?;
+        if compares_json_left {
+            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
+        } else {
+            self.visit_expression(left)?;
         }
 
-        self.visit_expression(right)?;
+        self.write(" < ")?;
 
-        if compares_json {
-            self.write(" AS JSON)")?;
+        if compares_json_right {
+            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
+        } else {
+            self.visit_expression(right)?;
         }
 
         Ok(())
     }
 
     fn visit_less_than_or_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        let compares_json = left.is_json_extract_fun() && right.is_json_value();
+        let compares_json_left = left.is_json_value() && right.is_json_extract_fun();
+        let compares_json_right = left.is_json_extract_fun() && right.is_json_value();
 
-        self.visit_expression(left)?;
-        self.write(" <= ")?;
-
-        if compares_json {
-            self.write("CAST(")?;
+        if compares_json_left {
+            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
+        } else {
+            self.visit_expression(left)?;
         }
 
-        self.visit_expression(right)?;
+        self.write(" <= ")?;
 
-        if compares_json {
-            self.write(" AS JSON)")?;
+        if compares_json_right {
+            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
+        } else {
+            self.visit_expression(right)?;
         }
 
         Ok(())

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -30,6 +30,28 @@ impl<'a> Mysql<'a> {
 
         Ok(())
     }
+
+    fn visit_numeric_comparison(&mut self, left: Expression<'a>, right: Expression<'a>, sign: &str) -> visitor::Result {
+        match (left, right) {
+            (left, right) if left.is_json_value() && right.is_json_extract_fun() => {
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
+                self.write(format!(" {} ", sign))?;
+                self.visit_expression(right)?;
+            }
+            (left, right) if left.is_json_extract_fun() && right.is_json_value() => {
+                self.visit_expression(left)?;
+                self.write(format!(" {} ", sign))?;
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
+            }
+            (left, right) => {
+                self.visit_expression(left)?;
+                self.write(format!(" {} ", sign))?;
+                self.visit_expression(right)?;
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl<'a> Visitor<'a> for Mysql<'a> {
@@ -410,73 +432,25 @@ impl<'a> Visitor<'a> for Mysql<'a> {
     }
 
     fn visit_greater_than(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        match (left, right) {
-            (left, right) if left.is_json_value() && right.is_json_extract_fun() => {
-                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
-                self.write(" > ")?;
-                self.visit_expression(right)?;
-            }
-            (left, right) if left.is_json_extract_fun() && right.is_json_value() => {
-                self.visit_expression(left)?;
-                self.write(" > ")?;
-                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
-            }
-            (left, right) => self.visit_greater_than(left, right)?,
-        }
+        self.visit_numeric_comparison(left, right, ">")?;
 
         Ok(())
     }
 
     fn visit_greater_than_or_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        match (left, right) {
-            (left, right) if left.is_json_value() && right.is_json_extract_fun() => {
-                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
-                self.write(" >= ")?;
-                self.visit_expression(right)?;
-            }
-            (left, right) if left.is_json_extract_fun() && right.is_json_value() => {
-                self.visit_expression(left)?;
-                self.write(" >= ")?;
-                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
-            }
-            (left, right) => self.visit_greater_than_or_equals(left, right)?,
-        }
+        self.visit_numeric_comparison(left, right, ">=")?;
 
         Ok(())
     }
 
     fn visit_less_than(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        match (left, right) {
-            (left, right) if left.is_json_value() && right.is_json_extract_fun() => {
-                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
-                self.write(" < ")?;
-                self.visit_expression(right)?;
-            }
-            (left, right) if left.is_json_extract_fun() && right.is_json_value() => {
-                self.visit_expression(left)?;
-                self.write(" < ")?;
-                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
-            }
-            (left, right) => self.visit_less_than(left, right)?,
-        }
+        self.visit_numeric_comparison(left, right, "<")?;
 
         Ok(())
     }
 
     fn visit_less_than_or_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        match (left, right) {
-            (left, right) if left.is_json_value() && right.is_json_extract_fun() => {
-                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
-                self.write(" <= ")?;
-                self.visit_expression(right)?;
-            }
-            (left, right) if left.is_json_extract_fun() && right.is_json_value() => {
-                self.visit_expression(left)?;
-                self.write(" <= ")?;
-                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
-            }
-            (left, right) => self.visit_less_than_or_equals(left, right)?,
-        }
+        self.visit_numeric_comparison(left, right, "<=")?;
 
         Ok(())
     }

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -410,84 +410,72 @@ impl<'a> Visitor<'a> for Mysql<'a> {
     }
 
     fn visit_greater_than(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        let compares_json_left = left.is_json_value() && right.is_json_extract_fun();
-        let compares_json_right = left.is_json_extract_fun() && right.is_json_value();
-
-        if compares_json_left {
-            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
-        } else {
-            self.visit_expression(left)?;
-        }
-
-        self.write(" > ")?;
-
-        if compares_json_right {
-            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
-        } else {
-            self.visit_expression(right)?;
+        match (left, right) {
+            (left, right) if left.is_json_value() && right.is_json_extract_fun() => {
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
+                self.write(" > ")?;
+                self.visit_expression(right)?;
+            }
+            (left, right) if left.is_json_extract_fun() && right.is_json_value() => {
+                self.visit_expression(left)?;
+                self.write(" > ")?;
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
+            }
+            (left, right) => self.visit_greater_than(left, right)?,
         }
 
         Ok(())
     }
 
     fn visit_greater_than_or_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        let compares_json_left = left.is_json_value() && right.is_json_extract_fun();
-        let compares_json_right = left.is_json_extract_fun() && right.is_json_value();
-
-        if compares_json_left {
-            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
-        } else {
-            self.visit_expression(left)?;
-        }
-
-        self.write(" >= ")?;
-
-        if compares_json_right {
-            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
-        } else {
-            self.visit_expression(right)?;
+        match (left, right) {
+            (left, right) if left.is_json_value() && right.is_json_extract_fun() => {
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
+                self.write(" >= ")?;
+                self.visit_expression(right)?;
+            }
+            (left, right) if left.is_json_extract_fun() && right.is_json_value() => {
+                self.visit_expression(left)?;
+                self.write(" >= ")?;
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
+            }
+            (left, right) => self.visit_greater_than_or_equals(left, right)?,
         }
 
         Ok(())
     }
 
     fn visit_less_than(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        let compares_json_left = left.is_json_value() && right.is_json_extract_fun();
-        let compares_json_right = left.is_json_extract_fun() && right.is_json_value();
-
-        if compares_json_left {
-            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
-        } else {
-            self.visit_expression(left)?;
-        }
-
-        self.write(" < ")?;
-
-        if compares_json_right {
-            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
-        } else {
-            self.visit_expression(right)?;
+        match (left, right) {
+            (left, right) if left.is_json_value() && right.is_json_extract_fun() => {
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
+                self.write(" < ")?;
+                self.visit_expression(right)?;
+            }
+            (left, right) if left.is_json_extract_fun() && right.is_json_value() => {
+                self.visit_expression(left)?;
+                self.write(" < ")?;
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
+            }
+            (left, right) => self.visit_less_than(left, right)?,
         }
 
         Ok(())
     }
 
     fn visit_less_than_or_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        let compares_json_left = left.is_json_value() && right.is_json_extract_fun();
-        let compares_json_right = left.is_json_extract_fun() && right.is_json_value();
-
-        if compares_json_left {
-            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
-        } else {
-            self.visit_expression(left)?;
-        }
-
-        self.write(" <= ")?;
-
-        if compares_json_right {
-            self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
-        } else {
-            self.visit_expression(right)?;
+        match (left, right) {
+            (left, right) if left.is_json_value() && right.is_json_extract_fun() => {
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(left))?;
+                self.write(" <= ")?;
+                self.visit_expression(right)?;
+            }
+            (left, right) if left.is_json_extract_fun() && right.is_json_value() => {
+                self.visit_expression(left)?;
+                self.write(" <= ")?;
+                self.surround_with("CAST(", " AS JSON)", |s| s.visit_expression(right))?;
+            }
+            (left, right) => self.visit_less_than_or_equals(left, right)?,
         }
 
         Ok(())


### PR DESCRIPTION
## Overview

Follow-up PR to #310.

- Ensures the cast can be rendered on both sides.
- (Unrelated) Adds `.vscode/` folder to .gitignore. This folder contains repo-specific configurations of VSCode. It can and should be git ignored. Let me know if you want a separate PR for that, I was just too lazy 🤕