### PR TITLE
feat(pg): add not_matches for full-text search

### DIFF
--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -496,4 +496,12 @@ impl<'a> Comparable<'a> for Expression<'a> {
     {
         Compare::Matches(Box::new(self), query.into())
     }
+
+    #[cfg(feature = "postgresql")]
+    fn not_matches<T>(self, query: T) -> Compare<'a>
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        Compare::NotMatches(Box::new(self), query.into())
+    }
 }

--- a/src/ast/row.rs
+++ b/src/ast/row.rs
@@ -394,4 +394,14 @@ impl<'a> Comparable<'a> for Row<'a> {
 
         value.matches(query)
     }
+
+    #[cfg(feature = "postgresql")]
+    fn not_matches<T>(self, query: T) -> Compare<'a>
+    where
+        T: Into<Cow<'a, str>>,
+    {
+        let value: Expression<'a> = self.into();
+
+        value.not_matches(query)
+    }
 }

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2538,5 +2538,13 @@ async fn text_search_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     assert_eq!(row["name"], Value::from("Chicken Curry"));
     assert_eq!(row["ingredients"], Value::from("Chicken, Curry, Rice"));
 
+    // Search on a single column with NOT
+    let search: Expression = text_search(&vec!["name"]).into();
+    let q = Select::from_table(&table).so_that(search.not_matches("salad"));
+    let row = api.conn().select(q).await?.into_single()?;
+
+    assert_eq!(row["name"], Value::from("Chicken Curry"));
+    assert_eq!(row["ingredients"], Value::from("Chicken, Curry, Rice"));
+
     Ok(())
 }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -121,7 +121,7 @@ pub trait Visitor<'a> {
     fn visit_text_search(&mut self, text_search: TextSearch<'a>) -> Result;
 
     #[cfg(feature = "postgresql")]
-    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>) -> Result;
+    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>, not: bool) -> Result;
 
     /// A visit to a value we parameterize
     fn visit_parameterized(&mut self, value: Value<'a>) -> Result {
@@ -879,7 +879,9 @@ pub trait Visitor<'a> {
                 JsonCompare::TypeEquals(left, json_type) => self.visit_json_type_equals(*left, json_type),
             },
             #[cfg(feature = "postgresql")]
-            Compare::Matches(left, right) => self.visit_matches(*left, right),
+            Compare::Matches(left, right) => self.visit_matches(*left, right, false),
+            #[cfg(feature = "postgresql")]
+            Compare::NotMatches(left, right) => self.visit_matches(*left, right, true),
         }
     }
 

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -626,7 +626,12 @@ impl<'a> Visitor<'a> for Mssql<'a> {
     }
 
     #[cfg(feature = "postgresql")]
-    fn visit_matches(&mut self, _left: Expression<'a>, _right: std::borrow::Cow<'a, str>) -> visitor::Result {
+    fn visit_matches(
+        &mut self,
+        _left: Expression<'a>,
+        _right: std::borrow::Cow<'a, str>,
+        _not: bool,
+    ) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on MSSQL")
     }
 }

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -461,7 +461,12 @@ impl<'a> Visitor<'a> for Mysql<'a> {
     }
 
     #[cfg(feature = "postgresql")]
-    fn visit_matches(&mut self, _left: Expression<'a>, _right: std::borrow::Cow<'a, str>) -> visitor::Result {
+    fn visit_matches(
+        &mut self,
+        _left: Expression<'a>,
+        _right: std::borrow::Cow<'a, str>,
+        _not: bool,
+    ) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on MySQL")
     }
 }

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -393,7 +393,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
     #[cfg(feature = "postgresql")]
     fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>, not: bool) -> visitor::Result {
         if not {
-            self.write("( NOT ")?;
+            self.write("(NOT ")?;
         }
 
         self.visit_expression(left)?;
@@ -401,7 +401,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         self.surround_with("to_tsquery(", ")", |s| s.visit_parameterized(Value::text(right)))?;
 
         if not {
-            self.write(" )")?;
+            self.write(")")?;
         }
 
         Ok(())

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -391,10 +391,20 @@ impl<'a> Visitor<'a> for Postgres<'a> {
     }
 
     #[cfg(feature = "postgresql")]
-    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>) -> visitor::Result {
+    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>, not: bool) -> visitor::Result {
+        if not {
+            self.write("( NOT ")?;
+        }
+
         self.visit_expression(left)?;
         self.write(" @@ ")?;
-        self.surround_with("to_tsquery(", ")", |s| s.visit_parameterized(Value::text(right)))
+        self.surround_with("to_tsquery(", ")", |s| s.visit_parameterized(Value::text(right)))?;
+
+        if not {
+            self.write(" )")?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -277,7 +277,12 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
     }
 
     #[cfg(feature = "postgresql")]
-    fn visit_matches(&mut self, _left: Expression<'a>, _right: std::borrow::Cow<'a, str>) -> visitor::Result {
+    fn visit_matches(
+        &mut self,
+        _left: Expression<'a>,
+        _right: std::borrow::Cow<'a, str>,
+        _not: bool,
+    ) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on SQLite")
     }
 }


### PR DESCRIPTION
## Overview

Supports `.not_matches()`, the inverse of `.matches()` for full-text search on Postgres