### PR TITLE
More secure SQL Server default TLS setting

### DIFF
--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -496,7 +496,7 @@ impl MssqlUrl {
             .remove("encrypt")
             .map(|param| EncryptMode::from_str(&param))
             .transpose()?
-            .unwrap_or(EncryptMode::Off);
+            .unwrap_or(EncryptMode::On);
 
         let trust_server_certificate = props
             .remove("trustservercertificate")


### PR DESCRIPTION
This means without defining the `encrypt` parameter, the current behavior would mean we enable TLS for the login, and turn it off for all other communication with the database.

The new default just keeps TLS on for the whole session. It's 2021, all sites use HTTPS already and why would the database connection be different...

Closes: https://github.com/prisma/prisma/issues/8863