### PR TITLE
Fix json negation

### DIFF
--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -587,7 +587,7 @@ mod tests {
     #[test]
     fn equality_with_a_json_value() {
         let expected = expected_values(
-            r#"SELECT `users`.* FROM `users` WHERE JSON_CONTAINS(`jsonField`, ?) AND JSON_CONTAINS(?, `jsonField`)"#,
+            r#"SELECT `users`.* FROM `users` WHERE (JSON_CONTAINS(`jsonField`, ?) AND JSON_CONTAINS(?, `jsonField`))"#,
             vec![serde_json::json!({"a": "b"}), serde_json::json!({"a": "b"})],
         );
 
@@ -602,7 +602,7 @@ mod tests {
     #[test]
     fn difference_with_a_json_value() {
         let expected = expected_values(
-            r#"SELECT `users`.* FROM `users` WHERE NOT JSON_CONTAINS(`jsonField`, ?) OR NOT JSON_CONTAINS(?, `jsonField`)"#,
+            r#"SELECT `users`.* FROM `users` WHERE (NOT JSON_CONTAINS(`jsonField`, ?) OR NOT JSON_CONTAINS(?, `jsonField`))"#,
             vec![serde_json::json!({"a": "b"}), serde_json::json!({"a": "b"})],
         );
 


### PR DESCRIPTION
Previously, negated single queries, like `ConditionTree::not("json".equals(Value::Json(Some(serde_json::Value::Null))))` were rendered incorrectly, like:
```
(NOT JSON_CONTAINS(`json`, ?) AND JSON_CONTAINS(?, `json`))
```

The above is incorrect, parens were missing. Fixed it for both the equals and not equals case.