### PR TITLE
fix: num-bigint version conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ features = ["bundled"]
 optional = true
 
 [dependencies.tiberius]
-version = "0.6.0"
+version = "0.6.4"
 optional = true
 features = ["sql-browser-tokio", "chrono", "bigdecimal"]
 

--- a/src/ast/compare.rs
+++ b/src/ast/compare.rs
@@ -680,8 +680,8 @@ pub trait Comparable<'a> {
     ///
     /// assert_eq!(
     ///   "SELECT `users`.* FROM `users` WHERE \
-    ///      JSON_CONTAINS(JSON_EXTRACT(`json`, ?), ?) AND \
-    ///      JSON_CONTAINS(?, JSON_EXTRACT(`json`, ?))",
+    ///      (JSON_CONTAINS(JSON_EXTRACT(`json`, ?), ?) AND \
+    ///      JSON_CONTAINS(?, JSON_EXTRACT(`json`, ?)))",
     ///   sql
     /// );
     /// assert_eq!(vec![
@@ -710,8 +710,8 @@ pub trait Comparable<'a> {
     ///
     /// assert_eq!(
     ///   "SELECT `users`.* FROM `users` WHERE \
-    ///      NOT JSON_CONTAINS(JSON_EXTRACT(`json`, ?), ?) OR \
-    ///      NOT JSON_CONTAINS(?, JSON_EXTRACT(`json`, ?))",
+    ///      (NOT JSON_CONTAINS(JSON_EXTRACT(`json`, ?), ?) OR \
+    ///      NOT JSON_CONTAINS(?, JSON_EXTRACT(`json`, ?)))",
     ///   sql
     /// );
     /// assert_eq!(vec![
@@ -740,8 +740,8 @@ pub trait Comparable<'a> {
     ///
     /// assert_eq!(
     ///   "SELECT `users`.* FROM `users` WHERE \
-    ///      JSON_CONTAINS(JSON_EXTRACT(`json`, CONCAT('$[', JSON_LENGTH(`json`) - 1, ']')), ?) AND \
-    ///      JSON_CONTAINS(?, JSON_EXTRACT(`json`, CONCAT('$[', JSON_LENGTH(`json`) - 1, ']')))",
+    ///      (JSON_CONTAINS(JSON_EXTRACT(`json`, CONCAT('$[', JSON_LENGTH(`json`) - 1, ']')), ?) AND \
+    ///      JSON_CONTAINS(?, JSON_EXTRACT(`json`, CONCAT('$[', JSON_LENGTH(`json`) - 1, ']'))))",
     ///   sql
     /// );
     /// assert_eq!(vec![
@@ -767,8 +767,8 @@ pub trait Comparable<'a> {
     ///
     /// assert_eq!(
     ///   "SELECT `users`.* FROM `users` WHERE \
-    ///      NOT JSON_CONTAINS(JSON_EXTRACT(`json`, CONCAT('$[', JSON_LENGTH(`json`) - 1, ']')), ?) OR \
-    ///      NOT JSON_CONTAINS(?, JSON_EXTRACT(`json`, CONCAT('$[', JSON_LENGTH(`json`) - 1, ']')))",
+    ///      (NOT JSON_CONTAINS(JSON_EXTRACT(`json`, CONCAT('$[', JSON_LENGTH(`json`) - 1, ']')), ?) OR \
+    ///      NOT JSON_CONTAINS(?, JSON_EXTRACT(`json`, CONCAT('$[', JSON_LENGTH(`json`) - 1, ']'))))",
     ///   sql
     /// );
     ///

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -7,15 +7,13 @@ use crate::{
     error::{Error, ErrorKind},
 };
 #[cfg(feature = "bigdecimal")]
-use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
+use bigdecimal::{num_bigint::BigInt, BigDecimal, FromPrimitive, ToPrimitive};
 use bit_vec::BitVec;
 use bytes::BytesMut;
 #[cfg(feature = "chrono")]
 use chrono::{DateTime, NaiveDateTime, Utc};
 #[cfg(feature = "bigdecimal")]
 pub(crate) use decimal::DecimalWrapper;
-#[cfg(feature = "bigdecimal")]
-use num_bigint::BigInt;
 use postgres_types::{FromSql, ToSql};
 use std::error::Error as StdError;
 use tokio_postgres::{

--- a/src/connector/postgres/conversion/decimal.rs
+++ b/src/connector/postgres/conversion/decimal.rs
@@ -1,7 +1,9 @@
-use bigdecimal::{BigDecimal, ToPrimitive, Zero};
+use bigdecimal::{
+    num_bigint::{BigInt, Sign},
+    BigDecimal, ToPrimitive, Zero,
+};
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::{BufMut, BytesMut};
-use num_bigint::{BigInt, Sign};
 use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 use std::{cmp, convert::TryInto, error, fmt, io::Cursor};
 


### PR DESCRIPTION
## Overview

Fixes num-bigint versions conflicts

## Notes

There are some unrelated rustdocs fixes in there. They're most likely related to https://github.com/prisma/quaint/pull/321 being merged before https://github.com/prisma/quaint/pull/319 without rebasing first.

## Todo

- [x] Merge https://github.com/prisma/tiberius/pull/174 first