### PR TITLE
fix(pg): json extraction works with json cols too

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,6 @@
 export TEST_MYSQL="mysql://root:prisma@localhost:3306/prisma"
 export TEST_MYSQL8="mysql://root:prisma@localhost:3307/prisma"
+export TEST_MYSQL_MARIADB="mysql://root:prisma@localhost:3308/prisma"
 export TEST_PSQL="postgres://postgres:prisma@localhost:5432/postgres"
 export TEST_MSSQL="jdbc:sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true"
 if command -v nix-shell &> /dev/null

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ mysql = ["mysql_async", "tokio/time", "lru-cache"]
 pooled = ["mobc"]
 serde-support = ["serde", "chrono/serde"]
 sqlite = ["rusqlite", "libsqlite3-sys", "tokio/sync"]
-bigdecimal = ["bigdecimal_", "num-bigint"]
+bigdecimal = ["bigdecimal_"]
 
 [dependencies]
 connection-string = "0.1.10"
@@ -133,12 +133,6 @@ features = ["sql-browser-tokio", "chrono", "bigdecimal"]
 version = "0.2.0"
 optional = true
 package = "bigdecimal"
-
-[dependencies.num-bigint]
-version = "0.4.0"
-default-features = false
-optional = true
-features = ["std"]
 
 [dependencies.uuid]
 version = "0.8"

--- a/src/ast/function/json_extract.rs
+++ b/src/ast/function/json_extract.rs
@@ -51,7 +51,7 @@ impl<'a> JsonPath<'a> {
 /// let extract: Expression = json_extract(Column::from(("users", "json")), JsonPath::array(["a", "b"]), false).into();
 /// let query = Select::from_table("users").so_that(extract.equals("c"));
 /// let (sql, params) = Postgres::build(query)?;
-/// assert_eq!("SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"json\"#>ARRAY[$1, $2]::text[]) = $3", sql);
+/// assert_eq!("SELECT \"users\".* FROM \"users\" WHERE (\"users\".\"json\"#>ARRAY[$1, $2]::text[])::jsonb = $3", sql);
 /// assert_eq!(vec![Value::text("a"), Value::text("b"), Value::text("c")], params);
 /// # Ok(())
 /// # }

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2026,11 +2026,9 @@ async fn json_extract_path_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "json", feature = "postgresql"))]
-#[test_each_connector(tags("postgresql"))]
-async fn json_extract_array_path_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+async fn json_extract_array_path_postgres(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
-        .create_table(&format!("{}, obj jsonb", api.autogen_id("id")))
+        .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
         .await?;
 
     let insert = Insert::single_into(&table).value("obj", serde_json::json!({ "a": { "b": "c" } }));
@@ -2077,15 +2075,25 @@ async fn json_extract_array_path_fun(api: &mut dyn TestApi) -> crate::Result<()>
     Ok(())
 }
 
-#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
-#[test_each_connector(tags("postgresql", "mysql"))]
-async fn json_array_contains_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_extract_array_path_fun_on_jsonb(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_extract_array_path_postgres(api, "jsonb").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_extract_array_path_fun_on_json(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_extract_array_path_postgres(api, "json").await?;
+
+    Ok(())
+}
+
+async fn json_array_contains(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     use test_setup::Tags;
 
-    let json_type = match api.system() {
-        "postgres" => "jsonb",
-        _ => "json",
-    };
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
         .await?;
@@ -2163,13 +2171,31 @@ async fn json_array_contains_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
-#[test_each_connector(tags("postgresql", "mysql"))]
-async fn json_array_not_contains_fun(api: &mut dyn TestApi) -> crate::Result<()> {
-    let json_type = match api.system() {
-        "postgres" => "jsonb",
-        _ => "json",
-    };
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_contains_fun_pg_jsonb(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_contains(api, "jsonb").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_contains_fun_pg_json(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_contains(api, "json").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "mysql"))]
+#[test_each_connector(tags("mysql"))]
+async fn json_array_contains_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_contains(api, "json").await?;
+
+    Ok(())
+}
+
+async fn json_array_not_contains(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
         .await?;
@@ -2202,13 +2228,31 @@ async fn json_array_not_contains_fun(api: &mut dyn TestApi) -> crate::Result<()>
     Ok(())
 }
 
-#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
-#[test_each_connector(tags("postgresql", "mysql"))]
-async fn json_array_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<()> {
-    let json_type = match api.system() {
-        "postgres" => "jsonb",
-        _ => "json",
-    };
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_not_contains_fun_pg_jsonb(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_not_contains(api, "jsonb").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_not_contains_fun_pg_json(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_not_contains(api, "json").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "mysql"))]
+#[test_each_connector(tags("mysql"))]
+async fn json_array_not_contains_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_not_contains(api, "json").await?;
+
+    Ok(())
+}
+
+async fn json_array_begins_with(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
         .await?;
@@ -2275,13 +2319,31 @@ async fn json_array_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<()> 
     Ok(())
 }
 
-#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
-#[test_each_connector(tags("postgresql", "mysql"))]
-async fn json_array_not_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<()> {
-    let json_type = match api.system() {
-        "postgres" => "jsonb",
-        _ => "json",
-    };
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_begins_with_fun_pg_jsonb(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_begins_with(api, "jsonb").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_begins_with_fun_pg_json(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_begins_with(api, "json").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "mysql"))]
+#[test_each_connector(tags("mysql"))]
+async fn json_array_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_begins_with(api, "json").await?;
+
+    Ok(())
+}
+
+async fn json_array_not_begins_with(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
         .await?;
@@ -2315,13 +2377,31 @@ async fn json_array_not_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<
     Ok(())
 }
 
-#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
-#[test_each_connector(tags("postgresql", "mysql"))]
-async fn json_array_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()> {
-    let json_type = match api.system() {
-        "postgres" => "jsonb",
-        _ => "json",
-    };
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_not_begins_with_fun_pg_jsonb(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_not_begins_with(api, "jsonb").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_not_begins_with_fun_pg_json(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_not_begins_with(api, "json").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "mysql"))]
+#[test_each_connector(tags("mysql"))]
+async fn json_array_not_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_not_begins_with(api, "json").await?;
+
+    Ok(())
+}
+
+async fn json_array_ends_into(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
         .await?;
@@ -2389,13 +2469,31 @@ async fn json_array_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
-#[test_each_connector(tags("postgresql", "mysql"))]
-async fn json_array_not_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()> {
-    let json_type = match api.system() {
-        "postgres" => "jsonb",
-        _ => "json",
-    };
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_ends_into_fun_pg_jsonb(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_ends_into(api, "jsonb").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_ends_into_fun_pg_json(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_ends_into(api, "json").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "mysql"))]
+#[test_each_connector(tags("mysql"))]
+async fn json_array_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_ends_into(api, "json").await?;
+
+    Ok(())
+}
+
+async fn json_array_not_ends_into(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
         .await?;
@@ -2430,13 +2528,31 @@ async fn json_array_not_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()
     Ok(())
 }
 
-#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
-#[test_each_connector(tags("postgresql", "mysql"))]
-async fn json_gt_gte_lt_lte_fun(api: &mut dyn TestApi) -> crate::Result<()> {
-    let json_type = match api.system() {
-        "postgres" => "jsonb",
-        _ => "json",
-    };
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_not_ends_into_fun_pg_jsonb(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_not_ends_into(api, "jsonb").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_array_not_ends_into_fun_pg_json(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_not_ends_into(api, "json").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "mysql"))]
+#[test_each_connector(tags("mysql"))]
+async fn json_array_not_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_array_not_ends_into(api, "json").await?;
+
+    Ok(())
+}
+
+async fn json_gt_gte_lt_lte(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, json {}", api.autogen_id("id"), json_type))
         .await?;
@@ -2575,6 +2691,30 @@ async fn json_gt_gte_lt_lte_fun(api: &mut dyn TestApi) -> crate::Result<()> {
         value_into_json(&res.get(2).unwrap()["json"])
     );
     assert_eq!(None, res.get(3));
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_gt_gte_lt_lte_fun_pg_jsonb(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_gt_gte_lt_lte(api, "jsonb").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "postgresql"))]
+#[test_each_connector(tags("postgresql"))]
+async fn json_gt_gte_lt_lte_fun_pg_json(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_gt_gte_lt_lte(api, "json").await?;
+
+    Ok(())
+}
+
+#[cfg(all(feature = "json", feature = "mysql"))]
+#[test_each_connector(tags("mysql"))]
+async fn json_gt_gte_lt_lte_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    json_gt_gte_lt_lte(api, "json").await?;
 
     Ok(())
 }

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2026,7 +2026,7 @@ async fn json_extract_path_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
+#[cfg(all(feature = "json", feature = "postgresql"))]
 async fn json_extract_array_path_postgres(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2026,6 +2026,7 @@ async fn json_extract_path_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "json")]
 async fn json_extract_array_path_postgres(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2091,6 +2092,7 @@ async fn json_extract_array_path_fun_on_json(api: &mut dyn TestApi) -> crate::Re
     Ok(())
 }
 
+#[cfg(feature = "json")]
 async fn json_array_contains(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     use test_setup::Tags;
 
@@ -2195,6 +2197,7 @@ async fn json_array_contains_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "json")]
 async fn json_array_not_contains(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2252,6 +2255,7 @@ async fn json_array_not_contains_fun(api: &mut dyn TestApi) -> crate::Result<()>
     Ok(())
 }
 
+#[cfg(feature = "json")]
 async fn json_array_begins_with(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2343,6 +2347,7 @@ async fn json_array_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<()> 
     Ok(())
 }
 
+#[cfg(feature = "json")]
 async fn json_array_not_begins_with(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2401,6 +2406,7 @@ async fn json_array_not_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<
     Ok(())
 }
 
+#[cfg(feature = "json")]
 async fn json_array_ends_into(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2493,6 +2499,7 @@ async fn json_array_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "json")]
 async fn json_array_not_ends_into(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2552,6 +2559,7 @@ async fn json_array_not_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()
     Ok(())
 }
 
+#[cfg(feature = "json")]
 async fn json_gt_gte_lt_lte(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, json {}", api.autogen_id("id"), json_type))

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2026,7 +2026,7 @@ async fn json_extract_path_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 async fn json_extract_array_path_postgres(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2092,7 +2092,7 @@ async fn json_extract_array_path_fun_on_json(api: &mut dyn TestApi) -> crate::Re
     Ok(())
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 async fn json_array_contains(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     use test_setup::Tags;
 
@@ -2197,7 +2197,7 @@ async fn json_array_contains_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 async fn json_array_not_contains(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2255,7 +2255,7 @@ async fn json_array_not_contains_fun(api: &mut dyn TestApi) -> crate::Result<()>
     Ok(())
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 async fn json_array_begins_with(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2347,7 +2347,7 @@ async fn json_array_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<()> 
     Ok(())
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 async fn json_array_not_begins_with(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2406,7 +2406,7 @@ async fn json_array_not_begins_with_fun(api: &mut dyn TestApi) -> crate::Result<
     Ok(())
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 async fn json_array_ends_into(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2499,7 +2499,7 @@ async fn json_array_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     Ok(())
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 async fn json_array_not_ends_into(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, obj {}", api.autogen_id("id"), json_type))
@@ -2559,7 +2559,7 @@ async fn json_array_not_ends_into_fun(api: &mut dyn TestApi) -> crate::Result<()
     Ok(())
 }
 
-#[cfg(feature = "json")]
+#[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 async fn json_gt_gte_lt_lte(api: &mut dyn TestApi, json_type: &str) -> crate::Result<()> {
     let table = api
         .create_table(&format!("{}, json {}", api.autogen_id("id"), json_type))

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -291,7 +291,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
                     }
                     Ok(())
                 })?;
-                self.write(")")
+                self.write(")::jsonb")
             }
         }
     }


### PR DESCRIPTION
## Overview
Related to https://github.com/prisma/prisma/issues/8977

Prior to this fix, json extraction was only working with columns of type `jsonb`. We now always cast the result of the JSON extraction to `::jsonb`.

Also, I've refactored the JSON filtering tests so that they test Postgres for both a column of type `jsonb` _and_ `json`.