### PR TITLE
feat(pg): support ts_rank() for order by relevance

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -69,6 +69,8 @@ pub(crate) enum FunctionType<'a> {
     JsonExtractFirstArrayElem(JsonExtractFirstArrayElem<'a>),
     #[cfg(feature = "postgresql")]
     TextSearch(TextSearch<'a>),
+    #[cfg(feature = "postgresql")]
+    TextSearchRelevance(TextSearchRelevance<'a>),
 }
 
 impl<'a> Aliasable<'a> for Function<'a> {
@@ -97,6 +99,9 @@ function!(JsonExtractFirstArrayElem);
 
 #[cfg(feature = "postgresql")]
 function!(TextSearch);
+
+#[cfg(feature = "postgresql")]
+function!(TextSearchRelevance);
 
 function!(
     RowNumber,

--- a/src/ast/function/search.rs
+++ b/src/ast/function/search.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 #[derive(Debug, Clone, PartialEq)]
 /// Holds the columns on which to perform a full-text search
 pub struct TextSearch<'a> {
-    pub(crate) columns: Vec<Column<'a>>,
+    pub(crate) columns: Vec<Expression<'a>>,
 }
 
 /// Performs a full-text search. Use it in combination with the `.matches()` comparable.
@@ -28,9 +28,9 @@ pub struct TextSearch<'a> {
 #[cfg(feature = "postgresql")]
 pub fn text_search<'a, T: Clone>(columns: &[T]) -> super::Function<'a>
 where
-    T: Into<Column<'a>>,
+    T: Into<Expression<'a>>,
 {
-    let columns: Vec<Column> = columns.iter().map(|c| c.clone().into()).collect();
+    let columns: Vec<Expression> = columns.iter().map(|c| c.clone().into()).collect();
     let fun = TextSearch { columns };
 
     fun.into()

--- a/src/ast/function/search.rs
+++ b/src/ast/function/search.rs
@@ -2,9 +2,9 @@ use crate::prelude::*;
 use std::borrow::Cow;
 
 #[derive(Debug, Clone, PartialEq)]
-/// Holds the columns on which to perform a full-text search
+/// Holds the expressions on which to perform a full-text search
 pub struct TextSearch<'a> {
-    pub(crate) columns: Vec<Expression<'a>>,
+    pub(crate) exprs: Vec<Expression<'a>>,
 }
 
 /// Performs a full-text search. Use it in combination with the `.matches()` comparable.
@@ -26,24 +26,24 @@ pub struct TextSearch<'a> {
 /// # }
 /// ```
 #[cfg(feature = "postgresql")]
-pub fn text_search<'a, T: Clone>(columns: &[T]) -> super::Function<'a>
+pub fn text_search<'a, T: Clone>(exprs: &[T]) -> super::Function<'a>
 where
     T: Into<Expression<'a>>,
 {
-    let columns: Vec<Expression> = columns.iter().map(|c| c.clone().into()).collect();
-    let fun = TextSearch { columns };
+    let exprs: Vec<Expression> = exprs.iter().map(|c| c.clone().into()).collect();
+    let fun = TextSearch { exprs };
 
     fun.into()
 }
 
 #[derive(Debug, Clone, PartialEq)]
-/// Holds the columns & query on which to perform a text-search ranking compute
+/// Holds the expressions & query on which to perform a text-search ranking compute
 pub struct TextSearchRelevance<'a> {
-    pub(crate) columns: Vec<Expression<'a>>,
+    pub(crate) exprs: Vec<Expression<'a>>,
     pub(crate) query: Cow<'a, str>,
 }
 
-/// Computes the relevance score of a full-text search query against some columns.
+/// Computes the relevance score of a full-text search query against some expressions.
 ///
 /// ```rust
 /// # use quaint::{ast::*, visitor::{Visitor, Postgres}};
@@ -62,14 +62,14 @@ pub struct TextSearchRelevance<'a> {
 /// # }
 /// ```
 #[cfg(feature = "postgresql")]
-pub fn text_search_relevance<'a, E: Clone, Q>(columns: &[E], query: Q) -> super::Function<'a>
+pub fn text_search_relevance<'a, E: Clone, Q>(exprs: &[E], query: Q) -> super::Function<'a>
 where
     E: Into<Expression<'a>>,
     Q: Into<Cow<'a, str>>,
 {
-    let columns: Vec<Expression> = columns.iter().map(|c| c.clone().into()).collect();
+    let exprs: Vec<Expression> = exprs.iter().map(|c| c.clone().into()).collect();
     let fun = TextSearchRelevance {
-        columns,
+        exprs,
         query: query.into(),
     };
 

--- a/src/ast/function/search.rs
+++ b/src/ast/function/search.rs
@@ -1,4 +1,5 @@
-use crate::prelude::Column;
+use crate::prelude::*;
+use std::borrow::Cow;
 
 #[derive(Debug, Clone, PartialEq)]
 /// Holds the columns on which to perform a full-text search
@@ -31,6 +32,46 @@ where
 {
     let columns: Vec<Column> = columns.iter().map(|c| c.clone().into()).collect();
     let fun = TextSearch { columns };
+
+    fun.into()
+}
+
+#[derive(Debug, Clone, PartialEq)]
+/// Holds the columns & query on which to perform a text-search ranking compute
+pub struct TextSearchRelevance<'a> {
+    pub(crate) columns: Vec<Expression<'a>>,
+    pub(crate) query: Cow<'a, str>,
+}
+
+/// Computes the relevance score of a full-text search query against some columns.
+///
+/// ```rust
+/// # use quaint::{ast::*, visitor::{Visitor, Postgres}};
+/// # fn main() -> Result<(), quaint::error::Error> {
+/// let relevance: Expression = text_search_relevance(&[Column::from("name"), Column::from("ingredients")], "chicken").into();
+/// let query = Select::from_table("recipes").so_that(relevance.greater_than(0.1));
+/// let (sql, params) = Postgres::build(query)?;
+///
+/// assert_eq!(
+///    "SELECT \"recipes\".* FROM \"recipes\" WHERE \
+///     ts_rank(to_tsvector(\"name\"|| ' ' ||\"ingredients\"), to_tsquery($1)) > $2", sql
+/// );
+///
+/// assert_eq!(params, vec![Value::from("chicken"), Value::from(0.1)]);
+/// # Ok(())    
+/// # }
+/// ```
+#[cfg(feature = "postgresql")]
+pub fn text_search_relevance<'a, E: Clone, Q>(columns: &[E], query: Q) -> super::Function<'a>
+where
+    E: Into<Expression<'a>>,
+    Q: Into<Cow<'a, str>>,
+{
+    let columns: Vec<Expression> = columns.iter().map(|c| c.clone().into()).collect();
+    let fun = TextSearchRelevance {
+        columns,
+        query: query.into(),
+    };
 
     fun.into()
 }

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2766,7 +2766,7 @@ async fn text_search_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     );
 
     // Search on a single column
-    let search: Expression = text_search(&vec!["name"]).into();
+    let search: Expression = text_search(&["name"]).into();
     let q = Select::from_table(&table).so_that(search.matches("chicken"));
     let row = api.conn().select(q).await?.into_single()?;
 
@@ -2774,12 +2774,47 @@ async fn text_search_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     assert_eq!(row["ingredients"], Value::from("Chicken, Curry, Rice"));
 
     // Search on a single column with NOT
-    let search: Expression = text_search(&vec!["name"]).into();
+    let search: Expression = text_search(&["name"]).into();
     let q = Select::from_table(&table).so_that(search.not_matches("salad"));
     let row = api.conn().select(q).await?.into_single()?;
 
     assert_eq!(row["name"], Value::from("Chicken Curry"));
     assert_eq!(row["ingredients"], Value::from("Chicken, Curry, Rice"));
+
+    Ok(())
+}
+
+#[cfg(feature = "postgresql")]
+#[test_each_connector(tags("postgresql"))]
+async fn text_search_relevance_fun(api: &mut dyn TestApi) -> crate::Result<()> {
+    let table = api.create_table("name varchar(255), ingredients varchar(255)").await?;
+
+    let insert_1 = Insert::single_into(&table)
+        .value("name", "Chicken Curry")
+        .value("ingredients", "Chicken, Curry, Rice");
+    let insert_2 = Insert::single_into(&table)
+        .value("name", "Caesar Salad")
+        .value("ingredients", "Salad, Chicken, Parmesan, Caesar Sauce");
+    api.conn().insert(insert_1.into()).await?;
+    api.conn().insert(insert_2.into()).await?;
+
+    // Compute search relevance on multiple columns at the same time
+    let search: Expression = text_search_relevance(&[col!("name"), col!("ingredients")], "chicken").into();
+    let q = Select::from_table(&table).value(search.alias("relevance"));
+    let mut res = api.conn().select(q).await?.into_iter();
+
+    assert_eq!(res.next().unwrap()["relevance"], Value::float(0.075990885));
+    assert_eq!(res.next().unwrap()["relevance"], Value::float(0.06079271));
+    assert_eq!(res.next(), None);
+
+    // Search on a single column
+    let search: Expression = text_search_relevance(&[col!("name")], "chicken").into();
+    let q = Select::from_table(&table).value(search.alias("relevance"));
+    let mut res = api.conn().select(q).await?.into_iter();
+
+    assert_eq!(res.next().unwrap()["relevance"], Value::float(0.06079271));
+    assert_eq!(res.next().unwrap()["relevance"], Value::float(0.0));
+    assert_eq!(res.next(), None);
 
     Ok(())
 }

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2751,7 +2751,7 @@ async fn text_search_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     api.conn().insert(insert_2.into()).await?;
 
     // Search on multiple columns at the same time
-    let search: Expression = text_search(&vec!["name", "ingredients"]).into();
+    let search: Expression = text_search(&[col!("name"), col!("ingredients")]).into();
     let q = Select::from_table(&table).so_that(search.matches("chicken"));
     let res = api.conn().select(q).await?;
     let row_one = res.get(0).unwrap();
@@ -2766,7 +2766,7 @@ async fn text_search_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     );
 
     // Search on a single column
-    let search: Expression = text_search(&["name"]).into();
+    let search: Expression = text_search(&[col!("name")]).into();
     let q = Select::from_table(&table).so_that(search.matches("chicken"));
     let row = api.conn().select(q).await?.into_single()?;
 
@@ -2774,7 +2774,7 @@ async fn text_search_fun(api: &mut dyn TestApi) -> crate::Result<()> {
     assert_eq!(row["ingredients"], Value::from("Chicken, Curry, Rice"));
 
     // Search on a single column with NOT
-    let search: Expression = text_search(&["name"]).into();
+    let search: Expression = text_search(&[col!("name")]).into();
     let q = Select::from_table(&table).so_that(search.not_matches("salad"));
     let row = api.conn().select(q).await?.into_single()?;
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1010,14 +1010,14 @@ pub trait Visitor<'a> {
             }
             #[cfg(feature = "postgresql")]
             FunctionType::TextSearchRelevance(text_search_relevance) => {
-                let len = text_search_relevance.columns.len();
-                let columns = text_search_relevance.columns;
+                let len = text_search_relevance.exprs.len();
+                let exprs = text_search_relevance.exprs;
                 let query = text_search_relevance.query;
 
                 self.write("ts_rank(")?;
                 self.surround_with("to_tsvector(", ")", |s| {
-                    for (i, column) in columns.into_iter().enumerate() {
-                        s.visit_expression(column)?;
+                    for (i, expr) in exprs.into_iter().enumerate() {
+                        s.visit_expression(expr)?;
 
                         if i < (len - 1) {
                             s.write("|| ' ' ||")?;

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1008,6 +1008,28 @@ pub trait Visitor<'a> {
             FunctionType::TextSearch(text_search) => {
                 self.visit_text_search(text_search)?;
             }
+            #[cfg(feature = "postgresql")]
+            FunctionType::TextSearchRelevance(text_search_relevance) => {
+                let len = text_search_relevance.columns.len();
+                let columns = text_search_relevance.columns;
+                let query = text_search_relevance.query;
+
+                self.write("ts_rank(")?;
+                self.surround_with("to_tsvector(", ")", |s| {
+                    for (i, column) in columns.into_iter().enumerate() {
+                        s.visit_expression(column)?;
+
+                        if i < (len - 1) {
+                            s.write("|| ' ' ||")?;
+                        }
+                    }
+
+                    Ok(())
+                })?;
+                self.write(", ")?;
+                self.surround_with("to_tsquery(", ")", |s| s.visit_parameterized(Value::text(query)))?;
+                self.write(")")?;
+            }
         };
 
         if let Some(alias) = fun.alias {

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -362,7 +362,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         let len = text_search.columns.len();
         self.surround_with("to_tsvector(", ")", |s| {
             for (i, column) in text_search.columns.into_iter().enumerate() {
-                s.visit_column(column)?;
+                s.visit_expression(column)?;
 
                 if i < (len - 1) {
                     s.write("|| ' ' ||")?;

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -359,10 +359,10 @@ impl<'a> Visitor<'a> for Postgres<'a> {
 
     #[cfg(feature = "postgresql")]
     fn visit_text_search(&mut self, text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
-        let len = text_search.columns.len();
+        let len = text_search.exprs.len();
         self.surround_with("to_tsvector(", ")", |s| {
-            for (i, column) in text_search.columns.into_iter().enumerate() {
-                s.visit_expression(column)?;
+            for (i, expr) in text_search.exprs.into_iter().enumerate() {
+                s.visit_expression(expr)?;
 
                 if i < (len - 1) {
                     s.write("|| ' ' ||")?;


### PR DESCRIPTION
## Overview

Feature for https://github.com/prisma/prisma-engines/pull/2203

- Adds support for the `ts_rank()` function to compute the relevance score of a query against some columns
- BREAKING: Refactor `text_search` to accept a `Vec<Expression>` instead of a `Vec<Column>`. We'll need that on the QE to pass coalesced columns in case they're nullable. (`ts_vector(COALESCE(col1, '') || ' ' || col2)`)