### PR TITLE
feat: add time 0.3 support for postgres

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ bit-vec = { version = "0.6.1", optional = true }
 bytes = { version = "1.0", optional = true }
 mobc = { version = "0.7.1", optional = true }
 serde = { version = "1.0", optional = true }
+time = { version = "0.3.4", optional = true, features = ["formatting", "parsing", "macros"] } 
 
 [dev-dependencies]
 once_cell = "1.3"
@@ -139,19 +140,19 @@ version = "0.8"
 optional = true
 
 [dependencies.tokio-postgres]
-features = ["with-uuid-0_8", "with-chrono-0_4", "with-serde_json-1", "with-bit-vec-0_6"]
-git = "https://github.com/pimeys/rust-postgres"
+features = ["with-uuid-0_8", "with-chrono-0_4", "with-serde_json-1", "with-bit-vec-0_6", "with-time-0_3"]
+git = "https://github.com/kyle-mccarthy/rust-postgres"
 branch = "pgbouncer-mode"
 optional = true
 
 [dependencies.postgres-types]
-features = ["with-uuid-0_8", "with-chrono-0_4", "with-serde_json-1", "with-bit-vec-0_6"]
-git = "https://github.com/pimeys/rust-postgres"
+features = ["with-uuid-0_8", "with-chrono-0_4", "with-serde_json-1", "with-bit-vec-0_6", "with-time-0_3"]
+git = "https://github.com/kyle-mccarthy/rust-postgres"
 branch = "pgbouncer-mode"
 optional = true
 
 [dependencies.postgres-native-tls]
-git = "https://github.com/pimeys/rust-postgres"
+git = "https://github.com/kyle-mccarthy/rust-postgres"
 branch = "pgbouncer-mode"
 optional = true
 

--- a/src/tests/types/postgres.rs
+++ b/src/tests/types/postgres.rs
@@ -309,3 +309,63 @@ test_type!(bytea_array(
         Value::bytes(b"BEEFBEEF".to_vec())
     ])
 ));
+
+#[cfg(feature = "time")]
+test_type!(date(
+    postgresql,
+    "date",
+    Value::Date(None),
+    Value::date(time::macros::date!(2020 - 4 - 20))
+));
+
+#[cfg(feature = "time")]
+test_type!(date_array(
+    postgresql,
+    "date[]",
+    Value::Array(None),
+    Value::array(vec![time::macros::date!(2020 - 4 - 20)])
+));
+
+#[cfg(feature = "time")]
+test_type!(time(
+    postgresql,
+    "time",
+    Value::Time(None),
+    Value::time(time::macros::time!(16:20:00))
+));
+
+#[cfg(feature = "time")]
+test_type!(time_array(
+    postgresql,
+    "time[]",
+    Value::Array(None),
+    Value::array(vec![time::macros::time!(16:20:00)])
+));
+
+#[cfg(feature = "time")]
+test_type!(timestamp(postgresql, "timestamp", Value::DateTime(None), {
+    let dt = time::macros::datetime!(2020-02-27 19:10:22 UTC);
+
+    Value::datetime(dt)
+}));
+
+#[cfg(feature = "time")]
+test_type!(timestamp_array(postgresql, "timestamp[]", Value::Array(None), {
+    let dt = time::macros::datetime!(2020-02-27 19:10:22 UTC);
+
+    Value::array(vec![dt])
+}));
+
+#[cfg(feature = "time")]
+test_type!(timestamptz(postgresql, "timestamptz", Value::DateTime(None), {
+    let dt = time::macros::datetime!(2020-02-27 19:10:22 UTC);
+
+    Value::datetime(dt)
+}));
+
+#[cfg(feature = "time")]
+test_type!(timestamptz_array(postgresql, "timestamptz[]", Value::Array(None), {
+    let dt = time::macros::datetime!(2020-02-27 19:10:22 UTC);
+
+    Value::array(vec![dt])
+}));


### PR DESCRIPTION
Adds support for the time crate (version 0.3) for postgres. Currently, I have rust-postgres pointing to my fork; however, I plan to point it back to the current repo once https://github.com/pimeys/rust-postgres/pull/3 is merged.