### PR TITLE
feat(Postgres): Support options field in connection string

### DIFF
--- a/src/pooled.rs
+++ b/src/pooled.rs
@@ -67,6 +67,7 @@
 //!   sessions.
 //! - `statement_cache_size`, number of prepared statements kept cached.
 //!   Defaults to 500. If `pgbouncer` mode is enabled, caching is always off.
+//! - `options` Specifies command-line options to send to the server at connection start. [Read more](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS)
 //!
 //! ## MySQL
 //!

--- a/src/single.rs
+++ b/src/single.rs
@@ -86,6 +86,7 @@ impl Quaint {
     /// - `statement_cache_size`, number of prepared statements kept cached.
     ///   Defaults to 500, which means caching is off. If `pgbouncer` mode is enabled,
     ///   caching is always off.
+    /// - `options` Specifies command-line options to send to the server at connection start. [Read more](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS)
     ///
     /// MySQL:
     ///


### PR DESCRIPTION
Add support for the `options` field in the postgres connection string https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNECT-OPTIONS

This resolves https://github.com/prisma/quaint/issues/338