### PR TITLE
feat(mysql): Add text search relevance to mysql

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -69,7 +69,7 @@ pub(crate) enum FunctionType<'a> {
     JsonExtractFirstArrayElem(JsonExtractFirstArrayElem<'a>),
     #[cfg(any(feature = "postgresql", feature = "mysql"))]
     TextSearch(TextSearch<'a>),
-    #[cfg(feature = "postgresql")]
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
     TextSearchRelevance(TextSearchRelevance<'a>),
 }
 
@@ -100,7 +100,7 @@ function!(JsonExtractFirstArrayElem);
 #[cfg(any(feature = "postgresql", feature = "mysql"))]
 function!(TextSearch);
 
-#[cfg(feature = "postgresql")]
+#[cfg(any(feature = "postgresql", feature = "mysql"))]
 function!(TextSearchRelevance);
 
 function!(

--- a/src/ast/function/search.rs
+++ b/src/ast/function/search.rs
@@ -54,7 +54,7 @@ pub struct TextSearchRelevance<'a> {
 ///
 /// assert_eq!(
 ///    "SELECT \"recipes\".* FROM \"recipes\" WHERE \
-///     ts_rank(to_tsvector(concat_ws(' ', \"name\",\"ingredients\"), to_tsquery($1)) > $2", sql
+///     ts_rank(to_tsvector(concat_ws(' ', \"name\",\"ingredients\")), to_tsquery($1)) > $2", sql
 /// );
 ///
 /// assert_eq!(params, vec![Value::from("chicken"), Value::from(0.1)]);

--- a/src/ast/function/search.rs
+++ b/src/ast/function/search.rs
@@ -54,14 +54,14 @@ pub struct TextSearchRelevance<'a> {
 ///
 /// assert_eq!(
 ///    "SELECT \"recipes\".* FROM \"recipes\" WHERE \
-///     ts_rank(to_tsvector(\"name\"|| ' ' ||\"ingredients\"), to_tsquery($1)) > $2", sql
+///     ts_rank(to_tsvector(concat_ws(' ', \"name\",\"ingredients\"), to_tsquery($1)) > $2", sql
 /// );
 ///
 /// assert_eq!(params, vec![Value::from("chicken"), Value::from(0.1)]);
 /// # Ok(())    
 /// # }
 /// ```
-#[cfg(feature = "postgresql")]
+#[cfg(any(feature = "postgresql", feature = "mysql"))]
 pub fn text_search_relevance<'a, E: Clone, Q>(exprs: &[E], query: Q) -> super::Function<'a>
 where
     E: Into<Expression<'a>>,

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -123,6 +123,9 @@ pub trait Visitor<'a> {
     #[cfg(any(feature = "postgresql", feature = "mysql"))]
     fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>, not: bool) -> Result;
 
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_text_search_relevance(&mut self, text_search_relevance: TextSearchRelevance<'a>) -> Result;
+
     /// A visit to a value we parameterize
     fn visit_parameterized(&mut self, value: Value<'a>) -> Result {
         self.add_parameter(value);
@@ -1023,27 +1026,9 @@ pub trait Visitor<'a> {
             FunctionType::TextSearch(text_search) => {
                 self.visit_text_search(text_search)?;
             }
-            #[cfg(feature = "postgresql")]
+            #[cfg(any(feature = "postgresql", feature = "mysql"))]
             FunctionType::TextSearchRelevance(text_search_relevance) => {
-                let len = text_search_relevance.exprs.len();
-                let exprs = text_search_relevance.exprs;
-                let query = text_search_relevance.query;
-
-                self.write("ts_rank(")?;
-                self.surround_with("to_tsvector(", ")", |s| {
-                    for (i, expr) in exprs.into_iter().enumerate() {
-                        s.visit_expression(expr)?;
-
-                        if i < (len - 1) {
-                            s.write("|| ' ' ||")?;
-                        }
-                    }
-
-                    Ok(())
-                })?;
-                self.write(", ")?;
-                self.surround_with("to_tsquery(", ")", |s| s.visit_parameterized(Value::text(query)))?;
-                self.write(")")?;
+                self.visit_text_search_relevance(text_search_relevance)?;
             }
         };
 

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -620,6 +620,14 @@ impl<'a> Visitor<'a> for Mssql<'a> {
         unimplemented!("Full-text search is not yet supported on MSSQL")
     }
 
+    #[cfg(feature = "postgresql")]
+    fn visit_text_search_relevance(
+        &mut self,
+        _text_search_relevance: crate::prelude::TextSearchRelevance<'a>,
+    ) -> visitor::Result {
+        unimplemented!("Full-text search is not yet supported on MSSQL")
+    }
+
     #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
     fn visit_json_extract_last_array_item(
         &mut self,

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -475,6 +475,18 @@ impl<'a> Visitor<'a> for Mysql<'a> {
         Ok(())
     }
 
+    #[cfg(any(feature = "postgresql", feature = "mysql"))]
+    fn visit_text_search_relevance(&mut self, text_search_relevance: TextSearchRelevance<'a>) -> visitor::Result {
+        let exprs = text_search_relevance.exprs;
+        let query = text_search_relevance.query;
+
+        let text_search = TextSearch { exprs };
+
+        self.visit_matches(text_search.into(), query, false)?;
+
+        Ok(())
+    }
+
     #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
     fn visit_json_extract_last_array_item(&mut self, extract: JsonExtractLastArrayElem<'a>) -> visitor::Result {
         self.write("JSON_EXTRACT(")?;

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -441,7 +441,6 @@ impl<'a> Visitor<'a> for Mysql<'a> {
         Ok(())
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
     fn visit_text_search(&mut self, text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
         let len = text_search.exprs.len();
         self.surround_with("MATCH (", ")", |s| {
@@ -457,7 +456,6 @@ impl<'a> Visitor<'a> for Mysql<'a> {
         })
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
     fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>, not: bool) -> visitor::Result {
         if not {
             self.write("(NOT ")?;
@@ -475,7 +473,6 @@ impl<'a> Visitor<'a> for Mysql<'a> {
         Ok(())
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
     fn visit_text_search_relevance(&mut self, text_search_relevance: TextSearchRelevance<'a>) -> visitor::Result {
         let exprs = text_search_relevance.exprs;
         let query = text_search_relevance.query;

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -362,7 +362,6 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         }
     }
 
-    #[cfg(feature = "postgresql")]
     fn visit_text_search(&mut self, text_search: crate::prelude::TextSearch<'a>) -> visitor::Result {
         let len = text_search.exprs.len();
         self.surround_with("to_tsvector(concat_ws(' ', ", "))", |s| {
@@ -378,7 +377,6 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         })
     }
 
-    #[cfg(feature = "postgresql")]
     fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>, not: bool) -> visitor::Result {
         if not {
             self.write("(NOT ")?;
@@ -395,7 +393,6 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         Ok(())
     }
 
-    #[cfg(any(feature = "postgresql", feature = "mysql"))]
     fn visit_text_search_relevance(&mut self, text_search_relevance: TextSearchRelevance<'a>) -> visitor::Result {
         let len = text_search_relevance.exprs.len();
         let exprs = text_search_relevance.exprs;

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -271,6 +271,11 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
         unimplemented!("Full-text search is not yet supported on SQLite")
     }
 
+    #[cfg(feature = "postgresql")]
+    fn visit_text_search_relevance(&mut self, _text_search_relevance: TextSearchRelevance<'a>) -> visitor::Result {
+        unimplemented!("Full-text search is not yet supported on SQLite")
+    }
+
     #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
     fn visit_json_extract_last_array_item(&mut self, _extract: JsonExtractLastArrayElem<'a>) -> visitor::Result {
         unimplemented!("JSON filtering is not yet supported on SQLite")


### PR DESCRIPTION
Adds `visit_text_search_relevance` support to mysql and refactors the
original postgres only support to allow any connector to be able to
implement it.