### PR TITLE
don't panic if decimals don't fit

### DIFF
--- a/src/connector/postgres/conversion/decimal.rs
+++ b/src/connector/postgres/conversion/decimal.rs
@@ -225,7 +225,7 @@ impl ToSql for DecimalWrapper {
         out.reserve(8 + num_digits * 2);
 
         // Number of groups
-        out.put_u16(num_digits.try_into().unwrap());
+        out.put_u16(num_digits.try_into()?);
 
         // Weight of first group
         out.put_i16(weight);


### PR DESCRIPTION
Hi, I'm hitting this in my prisma code if the big decimal is too large.
Found it with the number 6.673310573781466e+51 . Adding a check in my code but, regardless, I don't think the lib should panic.