### PR TITLE
Support Uuid_to_bin in MySQL

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -17,6 +17,9 @@ mod search;
 mod sum;
 mod upper;
 
+#[cfg(feature = "mysql")]
+mod uuid;
+
 pub use aggregate_to_string::*;
 pub use average::*;
 pub use coalesce::*;
@@ -35,6 +38,9 @@ pub use row_to_json::*;
 pub use search::*;
 pub use sum::*;
 pub use upper::*;
+
+#[cfg(feature = "mysql")]
+pub use self::uuid::*;
 
 use super::{Aliasable, Expression};
 use std::borrow::Cow;
@@ -71,30 +77,10 @@ pub(crate) enum FunctionType<'a> {
     TextSearch(TextSearch<'a>),
     #[cfg(any(feature = "postgresql", feature = "mysql"))]
     TextSearchRelevance(TextSearchRelevance<'a>),
-    #[cfg(any(feature = "mysql"))]
+    #[cfg(feature = "mysql")]
     UuidToBin,
-}
-
-/// Generates the function uuid_to_bin(uuid()) returning a binary uuid in MySQL
-/// ```rust
-/// # use quaint::{ast::*, visitor::{Visitor, Mysql}};
-/// # fn main() -> Result<(), quaint::error::Error> {
-
-/// let query = Select::default().value(uuid_to_bin());
-/// let (sql, _) = Mysql::build(query)?;
-///
-/// assert_eq!("SELECT uuid_to_bin(uuid())", sql);
-/// # Ok(())
-/// # }
-/// ```
-#[cfg(any(feature = "mysql"))]
-pub fn uuid_to_bin() -> Expression<'static> {
-    let func = Function {
-        typ_: FunctionType::UuidToBin,
-        alias: None,
-    };
-
-    func.into()
+    #[cfg(feature = "mysql")]
+    Uuid,
 }
 
 impl<'a> Aliasable<'a> for Function<'a> {

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -75,6 +75,18 @@ pub(crate) enum FunctionType<'a> {
     UuidToBin,
 }
 
+/// Generates the function uuid_to_bin(uuid()) returning a binary uuid in MySQL
+/// ```rust
+/// # use quaint::{ast::*, visitor::{Visitor, Mysql}};
+/// # fn main() -> Result<(), quaint::error::Error> {
+
+/// let query = Select::default().value(uuid_to_bin());
+/// let (sql, _) = Mysql::build(query)?;
+///
+/// assert_eq!("SELECT uuid_to_bin(uuid())", sql);
+/// # Ok(())
+/// # }
+/// ```
 #[cfg(any(feature = "mysql"))]
 pub fn uuid_to_bin() -> Expression<'static> {
     let func = Function {
@@ -96,22 +108,6 @@ impl<'a> Aliasable<'a> for Function<'a> {
         self
     }
 }
-
-// impl<'a> From<Uui> for Function<'a> {
-//     fn from(f: $kind<'a>) -> Self {
-//         Function {
-//             typ_: FunctionType::$kind(f),
-//             alias: None,
-//         }
-//     }
-// }
-
-
-// impl<'a> From<$kind<'a>> for Expression<'a> {
-//     fn from(f: $kind<'a>) -> Self {
-//         Function::from(f).into()
-//     }
-// }
 
 #[cfg(all(feature = "json", feature = "postgresql"))]
 function!(RowToJson);

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -71,6 +71,18 @@ pub(crate) enum FunctionType<'a> {
     TextSearch(TextSearch<'a>),
     #[cfg(any(feature = "postgresql", feature = "mysql"))]
     TextSearchRelevance(TextSearchRelevance<'a>),
+    #[cfg(any(feature = "mysql"))]
+    UuidToBin,
+}
+
+#[cfg(any(feature = "mysql"))]
+pub fn uuid_to_bin() -> Expression<'static> {
+    let func = Function {
+        typ_: FunctionType::UuidToBin,
+        alias: None
+    };
+
+    func.into()
 }
 
 impl<'a> Aliasable<'a> for Function<'a> {
@@ -84,6 +96,22 @@ impl<'a> Aliasable<'a> for Function<'a> {
         self
     }
 }
+
+// impl<'a> From<Uui> for Function<'a> {
+//     fn from(f: $kind<'a>) -> Self {
+//         Function {
+//             typ_: FunctionType::$kind(f),
+//             alias: None,
+//         }
+//     }
+// }
+
+
+// impl<'a> From<$kind<'a>> for Expression<'a> {
+//     fn from(f: $kind<'a>) -> Self {
+//         Function::from(f).into()
+//     }
+// }
 
 #[cfg(all(feature = "json", feature = "postgresql"))]
 function!(RowToJson);

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -91,7 +91,7 @@ pub(crate) enum FunctionType<'a> {
 pub fn uuid_to_bin() -> Expression<'static> {
     let func = Function {
         typ_: FunctionType::UuidToBin,
-        alias: None
+        alias: None,
     };
 
     func.into()

--- a/src/ast/function/uuid.rs
+++ b/src/ast/function/uuid.rs
@@ -1,0 +1,46 @@
+use super::{Function, FunctionType};
+use crate::ast::Expression;
+
+/// Generates the function uuid_to_bin(uuid()) returning a binary uuid in MySQL
+/// ```rust
+/// # use quaint::{ast::*, visitor::{Visitor, Mysql}};
+/// # fn main() -> Result<(), quaint::error::Error> {
+
+/// let query = Select::default().value(uuid_to_bin());
+/// let (sql, _) = Mysql::build(query)?;
+///
+/// assert_eq!("SELECT uuid_to_bin(uuid())", sql);
+/// # Ok(())
+/// # }
+/// ```
+#[cfg(feature = "mysql")]
+pub fn uuid_to_bin() -> Expression<'static> {
+    let func = Function {
+        typ_: FunctionType::UuidToBin,
+        alias: None,
+    };
+
+    func.into()
+}
+
+/// Generates the function uuid_to_bin(uuid()) returning a binary uuid in MySQL
+/// ```rust
+/// # use quaint::{ast::*, visitor::{Visitor, Mysql}};
+/// # fn main() -> Result<(), quaint::error::Error> {
+
+/// let query = Select::default().value(native_uuid());
+/// let (sql, _) = Mysql::build(query)?;
+///
+/// assert_eq!("SELECT uuid()", sql);
+/// # Ok(())
+/// # }
+/// ```
+#[cfg(any(feature = "mysql"))]
+pub fn native_uuid() -> Expression<'static> {
+    let func = Function {
+        typ_: FunctionType::Uuid,
+        alias: None,
+    };
+
+    func.into()
+}

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2879,7 +2879,7 @@ async fn generate_binary_uuid(api: &mut dyn TestApi) -> crate::Result<()> {
     let res = api.conn().select(select).await?.into_single()?;
     let val = res.into_single()?;
 
-    // Just check is a byte and it has some value, it is a uuid!
+    // If it is a byte type and has a value, it's a generated UUID.
     assert!(matches!(val, Value::Bytes(x) if matches!(x, Some(_))));
 
     Ok(())
@@ -2892,7 +2892,7 @@ async fn generate_native_uuid(api: &mut dyn TestApi) -> crate::Result<()> {
     let res = api.conn().select(select).await?.into_single()?;
     let val = res.into_single()?;
 
-    // Just check is a text and it has some value, it is a string uuid!
+    // If it is a text type and has a value, it's a generated string UUID.
     assert!(matches!(val, Value::Text(x) if matches!(x, Some(_))));
 
     Ok(())

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -2871,3 +2871,29 @@ async fn delete_comment(api: &mut dyn TestApi) -> crate::Result<()> {
 
     Ok(())
 }
+
+#[cfg(feature = "mysql")]
+#[test_each_connector(tags("mysql8"))]
+async fn generate_binary_uuid(api: &mut dyn TestApi) -> crate::Result<()> {
+    let select = Select::default().value(uuid_to_bin());
+    let res = api.conn().select(select).await?.into_single()?;
+    let val = res.into_single()?;
+
+    // Just check is a byte and it has some value, it is a uuid!
+    assert!(matches!(val, Value::Bytes(x) if matches!(x, Some(_))));
+
+    Ok(())
+}
+
+#[cfg(feature = "mysql")]
+#[test_each_connector(tags("mysql"))]
+async fn generate_native_uuid(api: &mut dyn TestApi) -> crate::Result<()> {
+    let select = Select::default().value(native_uuid());
+    let res = api.conn().select(select).await?.into_single()?;
+    let val = res.into_single()?;
+
+    // Just check is a text and it has some value, it is a string uuid!
+    assert!(matches!(val, Value::Text(x) if matches!(x, Some(_))));
+
+    Ok(())
+}

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1030,10 +1030,12 @@ pub trait Visitor<'a> {
             FunctionType::TextSearchRelevance(text_search_relevance) => {
                 self.visit_text_search_relevance(text_search_relevance)?;
             }
-            #[cfg(any(feature = "mysql"))]
+            #[cfg(feature = "mysql")]
             FunctionType::UuidToBin => {
                 self.write("uuid_to_bin(uuid())")?;
             }
+            #[cfg(feature = "mysql")]
+            FunctionType::Uuid => self.write("uuid()")?,
         };
 
         if let Some(alias) = fun.alias {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1032,7 +1032,7 @@ pub trait Visitor<'a> {
             }
             #[cfg(any(feature = "mysql"))]
             FunctionType::UuidToBin => {
-                self.write("(uuid_to_bin(uuid()))")?;
+                self.write("uuid_to_bin(uuid())")?;
             }
         };
 

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1030,6 +1030,10 @@ pub trait Visitor<'a> {
             FunctionType::TextSearchRelevance(text_search_relevance) => {
                 self.visit_text_search_relevance(text_search_relevance)?;
             }
+            #[cfg(any(feature = "mysql"))]
+            FunctionType::UuidToBin => {
+                self.write("(uuid_to_bin(uuid()))")?;
+            }
         };
 
         if let Some(alias) = fun.alias {


### PR DESCRIPTION
MySQL is the only main used database returning Uuid as a string, so they created an additional function, uuid_to_bin, to convert the string value to binary. This is a "feature" required for https://github.com/prisma/prisma/issues/7010.

This is the clearer of all the options... Another set of ideas could be:

 - Adding a `Literal(str)` function passing _anything_ you want to use as a function
 - Creating a new value type, `Unquoted` which is not going to be quoted as other `RawValue`s
 - Adding a new `Expression`, literal, similar to first option but using expression directly

At the end this was the clearer, of course it has a few tradeoffs:

 - It does not work in MySQL 5.x (uuid_to_bin)
 
This applies as well for the MySQL function `uuid` which generates a string instead of a binary