### PR TITLE
New default statement cache sizes for my and pg

### DIFF
--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -161,7 +161,7 @@ impl MysqlUrl {
         let mut max_connection_lifetime = None;
         let mut max_idle_connection_lifetime = Some(Duration::from_secs(300));
         let mut prefer_socket = None;
-        let mut statement_cache_size = 1000;
+        let mut statement_cache_size = 100;
 
         for (k, v) in url.query_pairs() {
             match k.as_ref() {
@@ -563,6 +563,19 @@ mod tests {
         assert_eq!(true, url.query_params.use_ssl);
         assert_eq!(false, url.query_params.ssl_opts.skip_domain_validation());
         assert_eq!(false, url.query_params.ssl_opts.accept_invalid_certs());
+    }
+
+    #[test]
+    fn should_allow_changing_of_cache_size() {
+        let url = MysqlUrl::new(Url::parse("mysql:///root:root@localhost:3307/foo?statement_cache_size=420").unwrap())
+            .unwrap();
+        assert_eq!(420, url.cache().capacity());
+    }
+
+    #[test]
+    fn should_have_default_cache_size() {
+        let url = MysqlUrl::new(Url::parse("mysql:///root:root@localhost:3307/foo").unwrap()).unwrap();
+        assert_eq!(100, url.cache().capacity());
     }
 
     #[tokio::test]

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -282,7 +282,7 @@ impl PostgresUrl {
         let mut connect_timeout = Some(Duration::from_secs(5));
         let mut pool_timeout = Some(Duration::from_secs(10));
         let mut pg_bouncer = false;
-        let mut statement_cache_size = 500;
+        let mut statement_cache_size = 100;
         let mut max_connection_lifetime = None;
         let mut max_idle_connection_lifetime = Some(Duration::from_secs(300));
         let mut options = None;
@@ -745,7 +745,7 @@ mod tests {
     #[test]
     fn should_have_default_cache_size() {
         let url = PostgresUrl::new(Url::parse("postgresql:///localhost:5432/foo").unwrap()).unwrap();
-        assert_eq!(500, url.cache().capacity());
+        assert_eq!(100, url.cache().capacity());
     }
 
     #[test]


### PR DESCRIPTION
Do not merge before Prisma 4.0!

MySQL      1000 -> 100
PostgreSQL  500 -> 100

The current defaults are confusing due to being different in the databases, and
too high due to users having multiple connections and multiple servers. This
leads to errors quite quickly.

Closes: https://github.com/prisma/prisma/issues/7727