### PR TITLE
feat: distinguish between `i32` and `i64`

### DIFF
--- a/src/ast/select.rs
+++ b/src/ast/select.rs
@@ -533,7 +533,7 @@ impl<'a> Select<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!("SELECT `users`.* FROM `users` LIMIT ?", sql);
-    /// assert_eq!(vec![Value::from(10)], params);
+    /// assert_eq!(vec![Value::from(10_i64)], params);
     /// # Ok(())
     /// # }
     pub fn limit(mut self, limit: usize) -> Self {
@@ -550,7 +550,7 @@ impl<'a> Select<'a> {
     /// let (sql, params) = Sqlite::build(query)?;
     ///
     /// assert_eq!("SELECT `users`.* FROM `users` LIMIT ? OFFSET ?", sql);
-    /// assert_eq!(vec![Value::from(-1), Value::from(10)], params);
+    /// assert_eq!(vec![Value::from(-1), Value::from(10_i64)], params);
     /// # Ok(())
     /// # }
     pub fn offset(mut self, offset: usize) -> Self {

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -40,8 +40,10 @@ where
 /// compatibility.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value<'a> {
+    /// 32-bit signed integer.
+    Int32(Option<i32>),
     /// 64-bit signed integer.
-    Integer(Option<i64>),
+    Int64(Option<i64>),
     /// 32-bit floating point.
     Float(Option<f32>),
     /// 64-bit floating point.
@@ -107,7 +109,8 @@ impl<'a> fmt::Display for Params<'a> {
 impl<'a> fmt::Display for Value<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let res = match self {
-            Value::Integer(val) => val.map(|v| write!(f, "{}", v)),
+            Value::Int32(val) => val.map(|v| write!(f, "{}", v)),
+            Value::Int64(val) => val.map(|v| write!(f, "{}", v)),
             Value::Float(val) => val.map(|v| write!(f, "{}", v)),
             Value::Double(val) => val.map(|v| write!(f, "{}", v)),
             Value::Text(val) => val.as_ref().map(|v| write!(f, "\"{}\"", v)),
@@ -155,7 +158,8 @@ impl<'a> fmt::Display for Value<'a> {
 impl<'a> From<Value<'a>> for serde_json::Value {
     fn from(pv: Value<'a>) -> Self {
         let res = match pv {
-            Value::Integer(i) => i.map(|i| serde_json::Value::Number(Number::from(i))),
+            Value::Int32(i) => i.map(|i| serde_json::Value::Number(Number::from(i))),
+            Value::Int64(i) => i.map(|i| serde_json::Value::Number(Number::from(i))),
             Value::Float(f) => f.map(|f| match Number::from_f64(f as f64) {
                 Some(number) => serde_json::Value::Number(number),
                 None => serde_json::Value::Null,
@@ -201,12 +205,28 @@ impl<'a> From<Value<'a>> for serde_json::Value {
 }
 
 impl<'a> Value<'a> {
-    /// Creates a new integer value.
+    /// Creates a new 32-bit signed integer.
+    pub fn int32<I>(value: I) -> Self
+    where
+        I: Into<i32>,
+    {
+        Value::Int32(Some(value.into()))
+    }
+
+    /// Creates a new 64-bit signed integer.
+    pub fn int64<I>(value: I) -> Self
+    where
+        I: Into<i64>,
+    {
+        Value::Int64(Some(value.into()))
+    }
+
+    /// Creates a new 64-bit signed integer.
     pub fn integer<I>(value: I) -> Self
     where
         I: Into<i64>,
     {
-        Value::Integer(Some(value.into()))
+        Value::Int64(Some(value.into()))
     }
 
     /// Creates a new decimal value.
@@ -321,7 +341,8 @@ impl<'a> Value<'a> {
     /// `true` if the `Value` is null.
     pub const fn is_null(&self) -> bool {
         match self {
-            Value::Integer(i) => i.is_none(),
+            Value::Int32(i) => i.is_none(),
+            Value::Int64(i) => i.is_none(),
             Value::Float(i) => i.is_none(),
             Value::Double(i) => i.is_none(),
             Value::Text(t) => t.is_none(),
@@ -410,15 +431,42 @@ impl<'a> Value<'a> {
         }
     }
 
-    /// `true` if the `Value` is an integer.
-    pub const fn is_integer(&self) -> bool {
-        matches!(self, Value::Integer(_))
+    /// `true` if the `Value` is a 32-bit signed integer.
+    pub const fn is_i32(&self) -> bool {
+        matches!(self, Value::Int32(_))
     }
 
-    /// Returns an `i64` if the value is an integer, otherwise `None`.
+    /// `true` if the `Value` is a 64-bit signed integer.
+    pub const fn is_i64(&self) -> bool {
+        matches!(self, Value::Int64(_))
+    }
+
+    /// `true` if the `Value` is a signed integer.
+    pub const fn is_integer(&self) -> bool {
+        matches!(self, Value::Int32(_) | Value::Int64(_))
+    }
+
+    /// Returns an `i64` if the value is a 64-bit signed integer, otherwise `None`.
     pub const fn as_i64(&self) -> Option<i64> {
         match self {
-            Value::Integer(i) => *i,
+            Value::Int64(i) => *i,
+            _ => None,
+        }
+    }
+
+    /// Returns an `i32` if the value is a 32-bit signed integer, otherwise `None`.
+    pub const fn as_i32(&self) -> Option<i32> {
+        match self {
+            Value::Int32(i) => *i,
+            _ => None,
+        }
+    }
+
+    /// Returns an `i64` if the value is a signed integer, otherwise `None`.
+    pub fn as_integer(&self) -> Option<i64> {
+        match self {
+            Value::Int32(i) => i.map(|i| i as i64),
+            Value::Int64(i) => *i,
             _ => None,
         }
     }
@@ -475,7 +523,8 @@ impl<'a> Value<'a> {
         match self {
             Value::Boolean(_) => true,
             // For schemas which don't tag booleans
-            Value::Integer(Some(i)) if *i == 0 || *i == 1 => true,
+            Value::Int32(Some(i)) if *i == 0 || *i == 1 => true,
+            Value::Int64(Some(i)) if *i == 0 || *i == 1 => true,
             _ => false,
         }
     }
@@ -485,7 +534,8 @@ impl<'a> Value<'a> {
         match self {
             Value::Boolean(b) => *b,
             // For schemas which don't tag booleans
-            Value::Integer(Some(i)) if *i == 0 || *i == 1 => Some(*i == 1),
+            Value::Int32(Some(i)) if *i == 0 || *i == 1 => Some(*i == 1),
+            Value::Int64(Some(i)) if *i == 0 || *i == 1 => Some(*i == 1),
             _ => None,
         }
     }
@@ -609,12 +659,12 @@ impl<'a> Value<'a> {
     }
 }
 
-value!(val: i64, Integer, val);
+value!(val: i64, Int64, val);
+value!(val: i32, Int32, val);
 value!(val: bool, Boolean, val);
 value!(val: &'a str, Text, val.into());
 value!(val: String, Text, val.into());
-value!(val: usize, Integer, i64::try_from(val).unwrap());
-value!(val: i32, Integer, i64::try_from(val).unwrap());
+value!(val: usize, Int64, i64::try_from(val).unwrap());
 value!(val: &'a [u8], Bytes, val.into());
 value!(val: f64, Double, val);
 value!(val: f32, Float, val);
@@ -644,6 +694,16 @@ impl<'a> TryFrom<Value<'a>> for i64 {
         value
             .as_i64()
             .ok_or_else(|| Error::builder(ErrorKind::conversion("Not an i64")).build())
+    }
+}
+
+impl<'a> TryFrom<Value<'a>> for i32 {
+    type Error = Error;
+
+    fn try_from(value: Value<'a>) -> Result<i32, Self::Error> {
+        value
+            .as_i32()
+            .ok_or_else(|| Error::builder(ErrorKind::conversion("Not an i32")).build())
     }
 }
 
@@ -792,8 +852,15 @@ mod tests {
     use std::str::FromStr;
 
     #[test]
-    fn a_parameterized_value_of_ints_can_be_converted_into_a_vec() {
+    fn a_parameterized_value_of_ints32_can_be_converted_into_a_vec() {
         let pv = Value::array(vec![1]);
+        let values: Vec<i32> = pv.into_vec().expect("convert into Vec<i32>");
+        assert_eq!(values, vec![1]);
+    }
+
+    #[test]
+    fn a_parameterized_value_of_ints64_can_be_converted_into_a_vec() {
+        let pv = Value::array(vec![1_i64]);
         let values: Vec<i64> = pv.into_vec().expect("convert into Vec<i64>");
         assert_eq!(values, vec![1]);
     }

--- a/src/connector/mssql/conversion.rs
+++ b/src/connector/mssql/conversion.rs
@@ -11,7 +11,8 @@ use tiberius::{ColumnData, FromSql, IntoSql};
 impl<'a> IntoSql<'a> for &'a Value<'a> {
     fn into_sql(self) -> ColumnData<'a> {
         match self {
-            Value::Integer(val) => val.into_sql(),
+            Value::Int32(val) => val.into_sql(),
+            Value::Int64(val) => val.into_sql(),
             Value::Float(val) => val.into_sql(),
             Value::Double(val) => val.into_sql(),
             Value::Text(val) => val.as_deref().into_sql(),
@@ -42,10 +43,10 @@ impl TryFrom<ColumnData<'static>> for Value<'static> {
 
     fn try_from(cd: ColumnData<'static>) -> crate::Result<Self> {
         let res = match cd {
-            ColumnData::U8(num) => Value::Integer(num.map(i64::from)),
-            ColumnData::I16(num) => Value::Integer(num.map(i64::from)),
-            ColumnData::I32(num) => Value::Integer(num.map(i64::from)),
-            ColumnData::I64(num) => Value::Integer(num.map(i64::from)),
+            ColumnData::U8(num) => Value::Int32(num.map(i32::from)),
+            ColumnData::I16(num) => Value::Int32(num.map(i32::from)),
+            ColumnData::I32(num) => Value::Int32(num.map(i32::from)),
+            ColumnData::I64(num) => Value::Int64(num.map(i64::from)),
             ColumnData::F32(num) => Value::Float(num),
             ColumnData::F64(num) => Value::Double(num),
             ColumnData::Bit(b) => Value::Boolean(b),

--- a/src/connector/sqlite/conversion.rs
+++ b/src/connector/sqlite/conversion.rs
@@ -40,8 +40,8 @@ impl TypeIdentifier for Column<'_> {
         matches!(
             self.decl_type(),
             Some("TINYINT")
-            | Some("tinyint")
-            | Some("SMALLINT")
+                | Some("tinyint")
+                | Some("SMALLINT")
                 | Some("smallint")
                 | Some("MEDIUMINT")
                 | Some("mediumint")
@@ -60,21 +60,18 @@ impl TypeIdentifier for Column<'_> {
         matches!(
             self.decl_type(),
             Some("BIGINT")
-            | Some("bigint")
-            | Some("UNSIGNED BIG INT")
-            | Some("unsigned big int")
-            | Some("INT8")
-            | Some("int8")
+                | Some("bigint")
+                | Some("UNSIGNED BIG INT")
+                | Some("unsigned big int")
+                | Some("INT8")
+                | Some("int8")
         )
     }
 
     fn is_datetime(&self) -> bool {
         matches!(
             self.decl_type(),
-            Some("DATETIME")
-            | Some("datetime")
-            | Some("TIMESTAMP")
-            | Some("timestamp")
+            Some("DATETIME") | Some("datetime") | Some("TIMESTAMP") | Some("timestamp")
         )
     }
 

--- a/src/connector/sqlite/conversion.rs
+++ b/src/connector/sqlite/conversion.rs
@@ -20,53 +20,61 @@ impl TypeIdentifier for Column<'_> {
         match self.decl_type() {
             Some(n) if n.starts_with("DECIMAL") => true,
             Some(n) if n.starts_with("decimal") => true,
-            Some("NUMERIC") | Some("REAL") => true,
-            Some("numeric") | Some("real") => true,
+            Some("NUMERIC") | Some("numeric") | Some("REAL") | Some("real") => true,
             _ => false,
         }
     }
 
     fn is_float(&self) -> bool {
-        matches!(self.decl_type(), Some("float") | Some("FLOAT"))
+        matches!(self.decl_type(), Some("FLOAT") | Some("float"))
     }
 
     fn is_double(&self) -> bool {
         matches!(
             self.decl_type(),
-            Some("double") | Some("DOUBLE") | Some("DOUBLE PRECISION") | Some("double precision")
+            Some("DOUBLE") | Some("double") | Some("DOUBLE PRECISION") | Some("double precision")
         )
     }
 
-    fn is_integer(&self) -> bool {
+    fn is_int32(&self) -> bool {
         matches!(
             self.decl_type(),
-            Some("INT")
+            Some("TINYINT")
+            | Some("tinyint")
+            | Some("SMALLINT")
+                | Some("smallint")
+                | Some("MEDIUMINT")
+                | Some("mediumint")
+                | Some("INT")
                 | Some("int")
                 | Some("INTEGER")
                 | Some("integer")
                 | Some("SERIAL")
                 | Some("serial")
-                | Some("TINYINT")
-                | Some("tinyint")
-                | Some("SMALLINT")
-                | Some("smallint")
-                | Some("MEDIUMINT")
-                | Some("mediumint")
-                | Some("BIGINT")
-                | Some("bigint")
-                | Some("UNSIGNED BIG INT")
-                | Some("unsigned big int")
                 | Some("INT2")
                 | Some("int2")
-                | Some("INT8")
-                | Some("int8")
+        )
+    }
+
+    fn is_int64(&self) -> bool {
+        matches!(
+            self.decl_type(),
+            Some("BIGINT")
+            | Some("bigint")
+            | Some("UNSIGNED BIG INT")
+            | Some("unsigned big int")
+            | Some("INT8")
+            | Some("int8")
         )
     }
 
     fn is_datetime(&self) -> bool {
         matches!(
             self.decl_type(),
-            Some("DATETIME") | Some("datetime") | Some("TIMESTAMP") | Some("timestamp")
+            Some("DATETIME")
+            | Some("datetime")
+            | Some("TIMESTAMP")
+            | Some("timestamp")
         )
     }
 
@@ -80,8 +88,8 @@ impl TypeIdentifier for Column<'_> {
 
     fn is_text(&self) -> bool {
         match self.decl_type() {
-            Some("TEXT") | Some("CLOB") => true,
-            Some("text") | Some("clob") => true,
+            Some("TEXT") | Some("text") => true,
+            Some("CLOB") | Some("clob") => true,
             Some(n) if n.starts_with("CHARACTER") => true,
             Some(n) if n.starts_with("character") => true,
             Some(n) if n.starts_with("VARCHAR") => true,
@@ -124,7 +132,7 @@ impl<'a> GetRow for SqliteRow<'a> {
         for (i, column) in self.columns().iter().enumerate() {
             let pv = match self.get_ref_unwrap(i) {
                 ValueRef::Null => match column {
-                    c if c.is_integer() | c.is_null() => Value::Integer(None),
+                    c if c.is_int32() | c.is_int64() | c.is_null() => Value::Int64(None),
                     c if c.is_text() => Value::Text(None),
                     c if c.is_bytes() => Value::Bytes(None),
                     c if c.is_float() => Value::Float(None),
@@ -143,7 +151,7 @@ impl<'a> GetRow for SqliteRow<'a> {
 
                             return Err(Error::builder(kind).build());
                         }
-                        None => Value::Integer(None),
+                        None => Value::Int64(None),
                     },
                 },
                 ValueRef::Integer(i) => match column {
@@ -164,7 +172,7 @@ impl<'a> GetRow for SqliteRow<'a> {
                         let dt = chrono::Utc.timestamp_millis(i);
                         Value::datetime(dt)
                     }
-                    _ => Value::integer(i),
+                    _ => Value::int64(i),
                 },
                 #[cfg(feature = "bigdecimal")]
                 ValueRef::Real(f) if column.is_real() => {
@@ -222,7 +230,8 @@ impl<'a> ToColumnNames for SqliteRows<'a> {
 impl<'a> ToSql for Value<'a> {
     fn to_sql(&self) -> Result<ToSqlOutput, RusqlError> {
         let value = match self {
-            Value::Integer(integer) => integer.map(ToSqlOutput::from),
+            Value::Int32(integer) => integer.map(ToSqlOutput::from),
+            Value::Int64(integer) => integer.map(ToSqlOutput::from),
             Value::Float(float) => float.map(|f| f as f64).map(ToSqlOutput::from),
             Value::Double(double) => double.map(ToSqlOutput::from),
             Value::Text(cow) => cow.as_ref().map(|cow| ToSqlOutput::from(cow.as_ref())),

--- a/src/connector/type_identifier.rs
+++ b/src/connector/type_identifier.rs
@@ -2,7 +2,8 @@ pub(crate) trait TypeIdentifier {
     fn is_real(&self) -> bool;
     fn is_float(&self) -> bool;
     fn is_double(&self) -> bool;
-    fn is_integer(&self) -> bool;
+    fn is_int32(&self) -> bool;
+    fn is_int64(&self) -> bool;
     fn is_datetime(&self) -> bool;
     fn is_time(&self) -> bool;
     fn is_date(&self) -> bool;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -76,7 +76,7 @@ impl<'de> Deserializer<'de> for RowDeserializer {
         let kvs = columns.iter().enumerate().map(move |(v, k)| {
             // The unwrap is safe if `columns` is correct.
             let value = values.get_mut(v).unwrap();
-            let taken_value = std::mem::replace(value, Value::Integer(None));
+            let taken_value = std::mem::replace(value, Value::Int64(None));
             (k.as_str(), taken_value)
         });
 
@@ -114,8 +114,10 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
             Value::Bytes(None) => visitor.visit_none(),
             Value::Enum(Some(s)) => visitor.visit_string(s.into_owned()),
             Value::Enum(None) => visitor.visit_none(),
-            Value::Integer(Some(i)) => visitor.visit_i64(i),
-            Value::Integer(None) => visitor.visit_none(),
+            Value::Int32(Some(i)) => visitor.visit_i32(i),
+            Value::Int32(None) => visitor.visit_none(),
+            Value::Int64(Some(i)) => visitor.visit_i64(i),
+            Value::Int64(None) => visitor.visit_none(),
             Value::Boolean(Some(b)) => visitor.visit_bool(b),
             Value::Boolean(None) => visitor.visit_none(),
             Value::Char(Some(c)) => visitor.visit_char(c),

--- a/src/tests/query/error.rs
+++ b/src/tests/query/error.rs
@@ -129,7 +129,7 @@ async fn null_constraint_violation(api: &mut dyn TestApi) -> crate::Result<()> {
     let insert = Insert::single_into(&table).value("id1", 50).value("id2", 55);
     api.conn().insert(insert.into()).await?;
 
-    let update = Update::table(&table).set("id2", Value::Integer(None));
+    let update = Update::table(&table).set("id2", Value::Int64(None));
     let res = api.conn().update(update).await;
 
     assert!(res.is_err());
@@ -334,7 +334,7 @@ async fn should_execute_multi_statement_queries_with_raw_cmd(api: &mut dyn TestA
 
     let results: Vec<i64> = results
         .into_iter()
-        .map(|row| row.get("id").unwrap().as_i64().unwrap())
+        .map(|row| row.get("id").unwrap().as_integer().unwrap())
         .collect();
 
     assert_eq!(results, &[51]);
@@ -346,7 +346,7 @@ async fn should_execute_multi_statement_queries_with_raw_cmd(api: &mut dyn TestA
 
     let results: Vec<i64> = results
         .into_iter()
-        .map(|row| row.get("id").unwrap().as_i64().unwrap())
+        .map(|row| row.get("id").unwrap().as_integer().unwrap())
         .collect();
 
     assert_eq!(results, &[52]);

--- a/src/tests/types/mssql.rs
+++ b/src/tests/types/mssql.rs
@@ -47,33 +47,33 @@ test_type!(text(mssql, "TEXT", Value::Text(None), Value::text("foobar")));
 test_type!(tinyint(
     mssql,
     "tinyint",
-    Value::Integer(None),
-    Value::integer(u8::MIN),
-    Value::integer(u8::MAX),
+    Value::Int32(None),
+    Value::int32(u8::MIN),
+    Value::int32(u8::MAX),
 ));
 
 test_type!(smallint(
     mssql,
     "smallint",
-    Value::Integer(None),
-    Value::integer(i16::MIN),
-    Value::integer(i16::MAX),
+    Value::Int32(None),
+    Value::int32(i16::MIN),
+    Value::int32(i16::MAX),
 ));
 
 test_type!(int(
     mssql,
     "int",
-    Value::Integer(None),
-    Value::integer(i32::MIN),
-    Value::integer(i32::MAX),
+    Value::Int32(None),
+    Value::int32(i32::MIN),
+    Value::int32(i32::MAX),
 ));
 
 test_type!(bigint(
     mssql,
     "bigint",
-    Value::Integer(None),
-    Value::integer(i64::MIN),
-    Value::integer(i64::MAX),
+    Value::Int64(None),
+    Value::int64(i64::MIN),
+    Value::int64(i64::MAX),
 ));
 
 test_type!(float_24(mssql, "float(24)", Value::Float(None), Value::float(1.23456),));

--- a/src/tests/types/mysql.rs
+++ b/src/tests/types/mysql.rs
@@ -5,89 +5,89 @@ use std::str::FromStr;
 test_type!(tinyint(
     mysql,
     "tinyint(4)",
-    Value::Integer(None),
-    Value::integer(i8::MIN),
-    Value::integer(i8::MAX)
+    Value::Int32(None),
+    Value::int32(i8::MIN),
+    Value::int32(i8::MAX)
 ));
 
 test_type!(tinyint1(
     mysql,
     "tinyint(1)",
-    Value::integer(-1),
-    Value::integer(1),
-    Value::integer(0)
+    Value::int32(-1),
+    Value::int32(1),
+    Value::int32(0)
 ));
 
 test_type!(tinyint_unsigned(
     mysql,
     "tinyint(4) unsigned",
-    Value::Integer(None),
-    Value::integer(0),
-    Value::integer(255)
+    Value::Int32(None),
+    Value::int32(0),
+    Value::int32(255)
 ));
 
 test_type!(year(
     mysql,
     "year",
-    Value::Integer(None),
-    Value::integer(1984),
-    Value::integer(2049)
+    Value::Int32(None),
+    Value::int32(1984),
+    Value::int32(2049)
 ));
 
 test_type!(smallint(
     mysql,
     "smallint",
-    Value::Integer(None),
-    Value::integer(i16::MIN),
-    Value::integer(i16::MAX)
+    Value::Int32(None),
+    Value::int32(i16::MIN),
+    Value::int32(i16::MAX)
 ));
 
 test_type!(smallint_unsigned(
     mysql,
     "smallint unsigned",
-    Value::Integer(None),
-    Value::integer(0),
-    Value::integer(65535)
+    Value::Int32(None),
+    Value::int32(0),
+    Value::int32(65535)
 ));
 
 test_type!(mediumint(
     mysql,
     "mediumint",
-    Value::Integer(None),
-    Value::integer(-8388608),
-    Value::integer(8388607)
+    Value::Int32(None),
+    Value::int32(-8388608),
+    Value::int32(8388607)
 ));
 
 test_type!(mediumint_unsigned(
     mysql,
     "mediumint unsigned",
-    Value::Integer(None),
-    Value::integer(0),
-    Value::integer(16777215)
+    Value::Int64(None),
+    Value::int64(0),
+    Value::int64(16777215)
 ));
 
 test_type!(int(
     mysql,
     "int",
-    Value::Integer(None),
-    Value::integer(i32::MIN),
-    Value::integer(i32::MAX)
+    Value::Int32(None),
+    Value::int32(i32::MIN),
+    Value::int32(i32::MAX)
 ));
 
 test_type!(int_unsigned(
     mysql,
     "int unsigned",
-    Value::Integer(None),
-    Value::integer(0),
-    Value::integer(4294967295i64)
+    Value::Int64(None),
+    Value::int64(0),
+    Value::int64(4294967295i64)
 ));
 
 test_type!(bigint(
     mysql,
     "bigint",
-    Value::Integer(None),
-    Value::integer(i64::MIN),
-    Value::integer(i64::MAX)
+    Value::Int64(None),
+    Value::int64(i64::MIN),
+    Value::int64(i64::MAX)
 ));
 
 #[cfg(feature = "bigdecimal")]

--- a/src/tests/types/postgres.rs
+++ b/src/tests/types/postgres.rs
@@ -23,9 +23,9 @@ test_type!(boolean_array(
 test_type!(int2(
     postgresql,
     "int2",
-    Value::Integer(None),
-    Value::integer(i16::MIN),
-    Value::integer(i16::MAX),
+    Value::Int32(None),
+    Value::int32(i16::MIN),
+    Value::int32(i16::MAX),
 ));
 
 test_type!(int2_array(
@@ -38,9 +38,9 @@ test_type!(int2_array(
 test_type!(int4(
     postgresql,
     "int4",
-    Value::Integer(None),
-    Value::integer(i32::MIN),
-    Value::integer(i32::MAX),
+    Value::Int32(None),
+    Value::int32(i32::MIN),
+    Value::int32(i32::MAX),
 ));
 
 test_type!(int4_array(
@@ -53,16 +53,16 @@ test_type!(int4_array(
 test_type!(int8(
     postgresql,
     "int8",
-    Value::Integer(None),
-    Value::integer(i64::MIN),
-    Value::integer(i64::MAX),
+    Value::Int64(None),
+    Value::int64(i64::MIN),
+    Value::int64(i64::MAX),
 ));
 
 test_type!(int8_array(
     postgresql,
     "int8[]",
     Value::Array(None),
-    Value::array(vec![1, 2, 3]),
+    Value::array(vec![1_64, 2_i64, 3_i64]),
 ));
 
 test_type!(float4(postgresql, "float4", Value::Float(None), Value::float(1.234)));
@@ -88,34 +88,34 @@ test_type!(float8_array(
     Value::array(vec![1.1234_f64, 4.321_f64])
 ));
 
-test_type!(oid(postgresql, "oid", Value::Integer(None), Value::integer(10000)));
+test_type!(oid(postgresql, "oid", Value::Int64(None), Value::integer(10000)));
 
 test_type!(oid_array(
     postgresql,
     "oid[]",
     Value::Array(None),
-    Value::array(vec![1, 2, 3]),
+    Value::array(vec![1_i64, 2_i64, 3_i64]),
 ));
 
 test_type!(serial2(
     postgresql,
     "serial2",
-    Value::integer(i16::MIN),
-    Value::integer(i16::MAX),
+    Value::int32(i16::MIN),
+    Value::int32(i16::MAX),
 ));
 
 test_type!(serial4(
     postgresql,
     "serial4",
-    Value::integer(i32::MIN),
-    Value::integer(i32::MAX),
+    Value::int32(i32::MIN),
+    Value::int32(i32::MAX),
 ));
 
 test_type!(serial8(
     postgresql,
     "serial8",
-    Value::integer(i64::MIN),
-    Value::integer(i64::MAX),
+    Value::int64(i64::MIN),
+    Value::int64(i64::MAX),
 ));
 
 test_type!(char(postgresql, "char(6)", Value::Text(None), Value::text("foobar")));

--- a/src/tests/types/sqlite.rs
+++ b/src/tests/types/sqlite.rs
@@ -6,18 +6,20 @@ use crate::{ast::*, connector::Queryable};
 #[cfg(feature = "bigdecimal")]
 use std::str::FromStr;
 
+// TODO: This should return Int32
+// Blocked by: https://github.com/prisma/prisma/issues/12784, which we'll fix for Prisma4
 test_type!(integer(
     sqlite,
     "INTEGER",
-    Value::Integer(None),
-    Value::integer(i8::MIN),
-    Value::integer(i8::MAX),
-    Value::integer(i16::MIN),
-    Value::integer(i16::MAX),
-    Value::integer(i32::MIN),
-    Value::integer(i32::MAX),
-    Value::integer(i64::MIN),
-    Value::integer(i64::MAX)
+    Value::Int64(None),
+    Value::int64(i8::MIN),
+    Value::int64(i8::MAX),
+    Value::int64(i16::MIN),
+    Value::int64(i16::MAX),
+    Value::int64(i32::MIN),
+    Value::int64(i32::MAX),
+    Value::int64(i64::MIN),
+    Value::int64(i64::MAX)
 ));
 
 #[cfg(feature = "bigdecimal")]

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -281,7 +281,8 @@ impl<'a> Visitor<'a> for Mssql<'a> {
 
     fn visit_raw_value(&mut self, value: Value<'a>) -> visitor::Result {
         let res = match value {
-            Value::Integer(i) => i.map(|i| self.write(i)),
+            Value::Int32(i) => i.map(|i| self.write(i)),
+            Value::Int64(i) => i.map(|i| self.write(i)),
             Value::Float(d) => d.map(|f| match f {
                 f if f.is_nan() => self.write("'NaN'"),
                 f if f == f32::INFINITY => self.write("'Infinity'"),
@@ -696,11 +697,11 @@ mod tests {
     #[test]
     fn test_aliased_null() {
         let expected_sql = "SELECT @P1 AS [test]";
-        let query = Select::default().value(val!(Value::Integer(None)).alias("test"));
+        let query = Select::default().value(val!(Value::Int32(None)).alias("test"));
         let (sql, params) = Mssql::build(query).unwrap();
 
         assert_eq!(expected_sql, sql);
-        assert_eq!(vec![Value::Integer(None)], params);
+        assert_eq!(vec![Value::Int32(None)], params);
     }
 
     #[test]
@@ -727,12 +728,7 @@ mod tests {
 
         assert_eq!(expected_sql, sql);
         assert_eq!(
-            vec![
-                Value::integer(1),
-                Value::integer(2),
-                Value::integer(3),
-                Value::integer(4),
-            ],
+            vec![Value::int32(1), Value::int32(2), Value::int32(3), Value::int32(4),],
             params
         );
     }
@@ -751,12 +747,7 @@ mod tests {
 
         assert_eq!(expected_sql, sql);
         assert_eq!(
-            vec![
-                Value::integer(1),
-                Value::integer(2),
-                Value::integer(3),
-                Value::integer(4),
-            ],
+            vec![Value::int32(1), Value::int32(2), Value::int32(3), Value::int32(4),],
             params
         );
     }
@@ -784,7 +775,7 @@ mod tests {
         let expected_sql = "SELECT [test].* FROM [test] WHERE [id1] IN (@P1,@P2)";
 
         assert_eq!(expected_sql, sql);
-        assert_eq!(vec![Value::integer(1), Value::integer(2),], params)
+        assert_eq!(vec![Value::int32(1), Value::int32(2),], params)
     }
 
     #[test]
@@ -959,7 +950,7 @@ mod tests {
     fn test_select_and() {
         let expected_sql = "SELECT [naukio].* FROM [naukio] WHERE ([word] = @P1 AND [age] < @P2 AND [paw] = @P3)";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = "word".equals("meow").and("age".less_than(10)).and("paw".equals("warm"));
         let query = Select::from_table("naukio").so_that(conditions);
@@ -973,7 +964,7 @@ mod tests {
     fn test_select_and_different_execution_order() {
         let expected_sql = "SELECT [naukio].* FROM [naukio] WHERE ([word] = @P1 AND ([age] < @P2 AND [paw] = @P3))";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = "word".equals("meow").and("age".less_than(10).and("paw".equals("warm")));
         let query = Select::from_table("naukio").so_that(conditions);
@@ -987,7 +978,7 @@ mod tests {
     fn test_select_or() {
         let expected_sql = "SELECT [naukio].* FROM [naukio] WHERE (([word] = @P1 OR [age] < @P2) AND [paw] = @P3)";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = "word".equals("meow").or("age".less_than(10)).and("paw".equals("warm"));
 
@@ -1004,7 +995,7 @@ mod tests {
         let expected_sql =
             "SELECT [naukio].* FROM [naukio] WHERE (NOT (([word] = @P1 OR [age] < @P2) AND [paw] = @P3))";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = "word"
             .equals("meow")
@@ -1025,7 +1016,7 @@ mod tests {
         let expected_sql =
             "SELECT [naukio].* FROM [naukio] WHERE (NOT (([word] = @P1 OR [age] < @P2) AND [paw] = @P3))";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = ConditionTree::not("word".equals("meow").or("age".less_than(10)).and("paw".equals("warm")));
         let query = Select::from_table("naukio").so_that(conditions);
@@ -1108,7 +1099,7 @@ mod tests {
         let (sql, params) = Mssql::build(query).unwrap();
 
         assert_eq!(expected_sql, sql);
-        assert_eq!(vec![Value::integer(0), Value::integer(10)], params);
+        assert_eq!(vec![Value::int32(0), Value::int64(10)], params);
     }
 
     #[test]
@@ -1626,7 +1617,7 @@ mod tests {
         let (sql, params) = Mssql::build(query).unwrap();
 
         assert_eq!(expected_sql, sql);
-        assert_eq!(vec![Value::integer(1), Value::integer(2)], params);
+        assert_eq!(vec![Value::int32(1), Value::int32(2)], params);
     }
 
     #[test]
@@ -1645,7 +1636,7 @@ mod tests {
         let (sql, params) = Mssql::build(query).unwrap();
 
         assert_eq!(expected_sql, sql);
-        assert_eq!(vec![Value::integer(1), Value::integer(2)], params);
+        assert_eq!(vec![Value::int32(1), Value::int32(2)], params);
     }
 
     #[test]
@@ -1672,12 +1663,7 @@ mod tests {
         assert_eq!(expected_sql, sql);
 
         assert_eq!(
-            vec![
-                Value::integer(1),
-                Value::integer(2),
-                Value::text("bar"),
-                Value::text("foo")
-            ],
+            vec![Value::int32(1), Value::int32(2), Value::text("bar"), Value::text("foo")],
             params
         );
     }
@@ -1705,12 +1691,7 @@ mod tests {
         assert_eq!(expected_sql, sql);
 
         assert_eq!(
-            vec![
-                Value::integer(1),
-                Value::integer(2),
-                Value::text("bar"),
-                Value::text("foo")
-            ],
+            vec![Value::int32(1), Value::int32(2), Value::text("bar"), Value::text("foo")],
             params
         );
     }
@@ -1741,12 +1722,7 @@ mod tests {
         assert_eq!(expected_sql, sql);
 
         assert_eq!(
-            vec![
-                Value::integer(1),
-                Value::integer(2),
-                Value::integer(3),
-                Value::integer(4)
-            ],
+            vec![Value::int32(1), Value::int32(2), Value::int32(3), Value::int32(4)],
             params
         );
     }

--- a/src/visitor/postgres.rs
+++ b/src/visitor/postgres.rs
@@ -71,7 +71,8 @@ impl<'a> Visitor<'a> for Postgres<'a> {
 
     fn visit_raw_value(&mut self, value: Value<'a>) -> visitor::Result {
         let res = match value {
-            Value::Integer(i) => i.map(|i| self.write(i)),
+            Value::Int32(i) => i.map(|i| self.write(i)),
+            Value::Int64(i) => i.map(|i| self.write(i)),
             Value::Text(t) => t.map(|t| self.write(format!("'{}'", t))),
             Value::Enum(e) => e.map(|e| self.write(e)),
             Value::Bytes(b) => b.map(|b| self.write(format!("E'{}'", hex::encode(b)))),
@@ -486,7 +487,10 @@ mod tests {
 
     #[test]
     fn test_limit_and_offset_when_both_are_set() {
-        let expected = expected_values("SELECT \"users\".* FROM \"users\" LIMIT $1 OFFSET $2", vec![10, 2]);
+        let expected = expected_values(
+            "SELECT \"users\".* FROM \"users\" LIMIT $1 OFFSET $2",
+            vec![10_i64, 2_i64],
+        );
         let query = Select::from_table("users").limit(10).offset(2);
         let (sql, params) = Postgres::build(query).unwrap();
 
@@ -496,7 +500,7 @@ mod tests {
 
     #[test]
     fn test_limit_and_offset_when_only_offset_is_set() {
-        let expected = expected_values("SELECT \"users\".* FROM \"users\" OFFSET $1", vec![10]);
+        let expected = expected_values("SELECT \"users\".* FROM \"users\" OFFSET $1", vec![10_i64]);
         let query = Select::from_table("users").offset(10);
         let (sql, params) = Postgres::build(query).unwrap();
 
@@ -506,7 +510,7 @@ mod tests {
 
     #[test]
     fn test_limit_and_offset_when_only_limit_is_set() {
-        let expected = expected_values("SELECT \"users\".* FROM \"users\" LIMIT $1", vec![10]);
+        let expected = expected_values("SELECT \"users\".* FROM \"users\" LIMIT $1", vec![10_i64]);
         let query = Select::from_table("users").limit(10);
         let (sql, params) = Postgres::build(query).unwrap();
 

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -43,7 +43,8 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
 
     fn visit_raw_value(&mut self, value: Value<'a>) -> visitor::Result {
         let res = match value {
-            Value::Integer(i) => i.map(|i| self.write(i)),
+            Value::Int32(i) => i.map(|i| self.write(i)),
+            Value::Int64(i) => i.map(|i| self.write(i)),
             Value::Text(t) => t.map(|t| self.write(format!("'{}'", t))),
             Value::Enum(e) => e.map(|e| self.write(e)),
             Value::Bytes(b) => b.map(|b| self.write(format!("x'{}'", hex::encode(b)))),
@@ -361,12 +362,7 @@ mod tests {
 
         assert_eq!(expected_sql, sql);
         assert_eq!(
-            vec![
-                Value::integer(1),
-                Value::integer(2),
-                Value::integer(3),
-                Value::integer(4),
-            ],
+            vec![Value::int32(1), Value::int32(2), Value::int32(3), Value::int32(4),],
             params
         );
     }
@@ -383,12 +379,7 @@ mod tests {
 
         assert_eq!(expected_sql, sql);
         assert_eq!(
-            vec![
-                Value::integer(1),
-                Value::integer(2),
-                Value::integer(3),
-                Value::integer(4),
-            ],
+            vec![Value::int32(1), Value::int32(2), Value::int32(3), Value::int32(4),],
             params
         );
     }
@@ -416,7 +407,7 @@ mod tests {
         let expected_sql = "SELECT `test`.* FROM `test` WHERE `id1` IN (?,?)";
 
         assert_eq!(expected_sql, sql);
-        assert_eq!(vec![Value::integer(1), Value::integer(2),], params)
+        assert_eq!(vec![Value::int32(1), Value::int32(2),], params)
     }
 
     #[test]
@@ -526,7 +517,7 @@ mod tests {
     fn test_select_and() {
         let expected_sql = "SELECT `naukio`.* FROM `naukio` WHERE (`word` = ? AND `age` < ? AND `paw` = ?)";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = "word".equals("meow").and("age".less_than(10)).and("paw".equals("warm"));
 
@@ -542,7 +533,7 @@ mod tests {
     fn test_select_and_different_execution_order() {
         let expected_sql = "SELECT `naukio`.* FROM `naukio` WHERE (`word` = ? AND (`age` < ? AND `paw` = ?))";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = "word".equals("meow").and("age".less_than(10).and("paw".equals("warm")));
 
@@ -558,7 +549,7 @@ mod tests {
     fn test_select_or() {
         let expected_sql = "SELECT `naukio`.* FROM `naukio` WHERE ((`word` = ? OR `age` < ?) AND `paw` = ?)";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = "word".equals("meow").or("age".less_than(10)).and("paw".equals("warm"));
 
@@ -574,7 +565,7 @@ mod tests {
     fn test_select_negation() {
         let expected_sql = "SELECT `naukio`.* FROM `naukio` WHERE (NOT ((`word` = ? OR `age` < ?) AND `paw` = ?))";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = "word"
             .equals("meow")
@@ -594,7 +585,7 @@ mod tests {
     fn test_with_raw_condition_tree() {
         let expected_sql = "SELECT `naukio`.* FROM `naukio` WHERE (NOT ((`word` = ? OR `age` < ?) AND `paw` = ?))";
 
-        let expected_params = vec![Value::text("meow"), Value::integer(10), Value::text("warm")];
+        let expected_params = vec![Value::text("meow"), Value::int32(10), Value::text("warm")];
 
         let conditions = ConditionTree::not("word".equals("meow").or("age".less_than(10)).and("paw".equals("warm")));
         let query = Select::from_table("naukio").so_that(conditions);


### PR DESCRIPTION
## Overview

### ⚠️ DO NOT MERGE YET

- Related to https://github.com/prisma/prisma/issues/12796
- Closes https://github.com/prisma/prisma/issues/12798
- Needed for https://github.com/prisma/prisma-engines/pull/2847

Splits `Value::Integer` into two new variants: `Value::Int32` and `Value::Int64`. SQLite does _not_ honor this contract yet as this would break Prisma, which we want to postpone for Prisma 4. For now, SQLite always returns `Int64` as it was already doing before.

You'll see a lot of TODOs in the tests which account for SQLite not returning `i32` where expected. This work is tracked by https://github.com/prisma/prisma/issues/12784.

**⚠️ For better readability, please read [ace6d3d](https://github.com/prisma/quaint/pull/355/commits/ace6d3d0623653096f7cb1f55da3e604e1f0b291) instead of the overall PR diff. `cargo fmt` prevents from having a clear diff, especially on conversion/postgres.rs**

**⚠️ Also, review the conversions carefully (FromSql & ToSql) as they might lead to unintended breaking changes in Prisma.**

## Changes

- (BREAKING) `Value::Integer` is removed. `Value::Int32` and `Value::Int64` replace it.
- (BREAKING) PostgreSQL, MySQL and MSSQL returns `Value::Int32` and `Value::Int64` accordingly now.
- (BREAKING) `Value::as_i64` only returns the `Value::Int64` variant now. 
- New `Value::as_integer()` method to be used instead of `Value::as_i64` for backward-compatibility.