### PR TITLE
feat: add unsupported column type error

### DIFF
--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -466,7 +466,7 @@ impl GetRow for PostgresRow {
                                         column_type: x.to_string(),
                                     };
 
-                                    return Err(Error::builder(kind).build().into());
+                                    return Err(Error::builder(kind).build());
                                 } else {
                                     Err(err)
                                 }
@@ -486,7 +486,7 @@ impl GetRow for PostgresRow {
                                     column_type: x.to_string(),
                                 };
 
-                                return Err(Error::builder(kind).build().into());
+                                return Err(Error::builder(kind).build());
                             } else {
                                 Err(err)
                             }

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -14,7 +14,7 @@ use bytes::BytesMut;
 use chrono::{DateTime, NaiveDateTime, Utc};
 #[cfg(feature = "bigdecimal")]
 pub(crate) use decimal::DecimalWrapper;
-use postgres_types::{FromSql, ToSql};
+use postgres_types::{FromSql, ToSql, WrongType};
 use std::error::Error as StdError;
 use tokio_postgres::{
     types::{self, IsNull, Kind, Type as PostgresType},
@@ -437,6 +437,7 @@ impl GetRow for PostgresRow {
                     Kind::Enum(_) => match row.try_get(i)? {
                         Some(val) => {
                             let val: EnumString = val;
+
                             Value::enum_variant(val.value)
                         }
                         None => Value::Enum(None),
@@ -446,26 +447,51 @@ impl GetRow for PostgresRow {
                             Some(val) => {
                                 let val: Vec<EnumString> = val;
                                 let variants = val.into_iter().map(|x| Value::enum_variant(x.value));
-                                Value::array(variants)
+
+                                Ok(Value::array(variants))
                             }
-                            None => Value::Array(None),
+                            None => Ok(Value::Array(None)),
                         },
-                        _ => match row.try_get(i)? {
-                            Some(val) => {
+                        _ => match row.try_get(i) {
+                            Ok(Some(val)) => {
                                 let val: Vec<String> = val;
                                 let strings = val.into_iter().map(Value::text);
-                                Value::array(strings)
+
+                                Ok(Value::array(strings))
                             }
-                            None => Value::Array(None),
+                            Ok(None) => Ok(Value::Array(None)),
+                            Err(err) => {
+                                if err.source().map(|err| err.is::<WrongType>()).unwrap_or(false) {
+                                    let kind = ErrorKind::UnsupportedColumnType {
+                                        column_type: x.to_string(),
+                                    };
+
+                                    return Err(Error::builder(kind).build().into());
+                                } else {
+                                    Err(err)
+                                }
+                            }
                         },
-                    },
-                    _ => match row.try_get(i)? {
-                        Some(val) => {
+                    }?,
+                    _ => match row.try_get(i) {
+                        Ok(Some(val)) => {
                             let val: String = val;
-                            Value::text(val)
+
+                            Ok(Value::text(val))
                         }
-                        None => Value::Text(None),
-                    },
+                        Ok(None) => Ok(Value::Text(None)),
+                        Err(err) => {
+                            if err.source().map(|err| err.is::<WrongType>()).unwrap_or(false) {
+                                let kind = ErrorKind::UnsupportedColumnType {
+                                    column_type: x.to_string(),
+                                };
+
+                                return Err(Error::builder(kind).build().into());
+                            } else {
+                                Err(err)
+                            }
+                        }
+                    }?,
                 },
             };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -248,6 +248,9 @@ pub enum ErrorKind {
 
     #[error("Cannot find a FULLTEXT index to use for the search")]
     MissingFullTextSearchIndex,
+
+    #[error("Column type '{}' could not be deserialized from the database.", column_type)]
+    UnsupportedColumnType { column_type: String },
 }
 
 impl ErrorKind {

--- a/src/tests/query/error.rs
+++ b/src/tests/query/error.rs
@@ -371,18 +371,37 @@ async fn uuid_length_error(api: &mut dyn TestApi) -> crate::Result<()> {
 
 #[test_each_connector(tags("postgresql"))]
 async fn unsupported_column_type(api: &mut dyn TestApi) -> crate::Result<()> {
-    let table = api.create_table("loc point").await?;
+    let table = api.create_table("point point, points point[]").await?;
     api.conn()
-        .query_raw(&format!(r#"INSERT INTO {} ("loc") VALUES (Point(1,2))"#, &table), &[])
+        .query_raw(
+            &format!(
+                r#"INSERT INTO {} ("point", "points") VALUES (Point(1,2), '{{"(1, 2)", "(2, 3)"}}')"#,
+                &table
+            ),
+            &[],
+        )
         .await?;
 
-    let result = api.conn().query(Select::from_table(table).column("loc").into()).await;
-
+    // Scalar
+    let result = api
+        .conn()
+        .query(Select::from_table(&table).column("point").into())
+        .await;
     let err = result.unwrap_err();
-
     assert!(matches!(
         err.kind(),
         ErrorKind::UnsupportedColumnType { column_type } if column_type.as_str() == "point"
+    ));
+
+    // Scalar list
+    let result = api
+        .conn()
+        .query(Select::from_table(&table).column("points").into())
+        .await;
+    let err = result.unwrap_err();
+    assert!(matches!(
+        err.kind(),
+        ErrorKind::UnsupportedColumnType { column_type } if column_type.as_str() == "_point"
     ));
 
     Ok(())


### PR DESCRIPTION
## Overview

Related to a bunch of queryRaw issues where folks query raw Unsupported columns (eg: https://github.com/prisma/prisma/issues/12344), leading to the following unhelpful error:

```
error deserializing column 7: cannot convert between the Rust type core::option::Option::alloc::string::String and the Postgres typetsvector
```

This PR provides a known Quaint error for those cases which [enables the Query Engine](https://github.com/prisma/prisma-engines/pull/2882) to match it and provide even more context.