### PR TITLE
Compile tiberius with rustls on macos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ name = "quaint"
 readme = "README.md"
 repository = "https://github.com/prisma/quaint/"
 version = "0.2.0-alpha.13"
+resolver = "2"
 
 [package.metadata.docs.rs]
 features = ["docs", "all"]
@@ -43,7 +44,6 @@ all = [
 ]
 
 vendored-openssl = [
-  "tiberius/vendored-openssl",
   "postgres-native-tls/vendored-openssl",
   "mysql_async/vendored-openssl"
 ]
@@ -124,10 +124,16 @@ default-features = false
 features = ["bundled"]
 optional = true
 
-[dependencies.tiberius]
-version = "0.7.3"
+[target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies.tiberius]
+version = "0.9.0"
 optional = true
 features = ["sql-browser-tokio", "chrono", "bigdecimal"]
+
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.tiberius]
+version = "0.9.0"
+optional = true
+default-features = false
+features = ["sql-browser-tokio", "rustls", "chrono", "bigdecimal", "tds73", "winauth"]
 
 [dependencies.bigdecimal_]
 version = "0.2.0"

--- a/src/tests/types/mssql.rs
+++ b/src/tests/types/mssql.rs
@@ -83,7 +83,7 @@ test_type!(real(mssql, "real", Value::Float(None), Value::float(1.123456)));
 test_type!(float_53(
     mssql,
     "float(53)",
-    Value::Float(None),
+    Value::Double(None),
     Value::double(1.1234567891)
 ));
 

--- a/src/tests/types/mssql/bigdecimal.rs
+++ b/src/tests/types/mssql/bigdecimal.rs
@@ -175,7 +175,7 @@ test_type!(real(
 test_type!(float_53(
     mssql,
     "float(53)",
-    (Value::Numeric(None), Value::Float(None)),
+    (Value::Numeric(None), Value::Double(None)),
     (
         Value::numeric(BigDecimal::from_str("1.123456789012345")?),
         Value::double(1.123456789012345)

--- a/test-macros/Cargo.toml
+++ b/test-macros/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-quaint = { path = "../" }
 darling = "0.10.1"
 syn = "1.0.5"
 quote = "1.0.2"

--- a/test-setup/Cargo.toml
+++ b/test-setup/Cargo.toml
@@ -10,4 +10,4 @@ bitflags = "1.2.1"
 async-trait = "0.1"
 names = "0.11"
 tokio = { version = "1.0", features = ["rt-multi-thread"]}
-quaint = { path = ".." }
+quaint = { path = "..", features = ["all"] }


### PR DESCRIPTION
Using the new resolver version, and new Tiberius version, rely on statically linked rustls instead of hacks with openssl/security framework to get TLS working with SQL Server on macOS.