### PR TITLE
Add support for "swapped" UUIDs in MySQL

### DIFF
--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -80,6 +80,8 @@ pub(crate) enum FunctionType<'a> {
     #[cfg(feature = "mysql")]
     UuidToBin,
     #[cfg(feature = "mysql")]
+    UuidToBinSwapped,
+    #[cfg(feature = "mysql")]
     Uuid,
 }
 

--- a/src/ast/function/uuid.rs
+++ b/src/ast/function/uuid.rs
@@ -23,6 +23,27 @@ pub fn uuid_to_bin() -> Expression<'static> {
     func.into()
 }
 
+/// Generates an optimized swapped UUID in MySQL 8
+/// see https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_uuid-to-bin
+/// ```rust
+/// # use quaint::{ast::*, visitor::{Visitor, Mysql}};
+/// # fn main() -> Result<(), quaint::error::Error> {
+/// let query = Select::default().value(uuid_to_bin_swapped());
+/// let (sql, _) = Mysql::build(query)?;
+/// 
+/// assert_eq!("SELECT uuid_to_bin(uuid(), 1)", sql);
+/// # Ok(())
+/// # }
+/// ```
+pub fn uuid_to_bin_swapped() -> Expression<'static> {
+    let func = Function {
+        typ_: FunctionType::UuidToBinSwapped,
+        alias: None
+    };
+
+    func.into()
+}
+
 /// Generates the function uuid_to_bin(uuid()) returning a binary uuid in MySQL
 /// ```rust
 /// # use quaint::{ast::*, visitor::{Visitor, Mysql}};

--- a/src/ast/function/uuid.rs
+++ b/src/ast/function/uuid.rs
@@ -30,7 +30,7 @@ pub fn uuid_to_bin() -> Expression<'static> {
 /// # fn main() -> Result<(), quaint::error::Error> {
 /// let query = Select::default().value(uuid_to_bin_swapped());
 /// let (sql, _) = Mysql::build(query)?;
-/// 
+///
 /// assert_eq!("SELECT uuid_to_bin(uuid(), 1)", sql);
 /// # Ok(())
 /// # }
@@ -38,7 +38,7 @@ pub fn uuid_to_bin() -> Expression<'static> {
 pub fn uuid_to_bin_swapped() -> Expression<'static> {
     let func = Function {
         typ_: FunctionType::UuidToBinSwapped,
-        alias: None
+        alias: None,
     };
 
     func.into()

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -3070,6 +3070,19 @@ async fn generate_binary_uuid(api: &mut dyn TestApi) -> crate::Result<()> {
 }
 
 #[cfg(feature = "mysql")]
+#[test_each_connector(tags("mysql8"))]
+async fn generate_swapped_binary_uuid(api: &mut dyn TestApi) -> crate::Result<()> {
+    let select = Select::default().value(uuid_to_bin_swapped());
+    let res = api.conn().select(select).await?.into_single()?;
+    let val = res.into_single()?;
+
+    // If it is a byte type and has a value, it's a generated UUID.
+    assert!(matches!(val, Value::Bytes(x) if matches!(x, Some(_))));
+
+    Ok(())
+}
+
+#[cfg(feature = "mysql")]
 #[test_each_connector(tags("mysql"))]
 async fn generate_native_uuid(api: &mut dyn TestApi) -> crate::Result<()> {
     let select = Select::default().value(native_uuid());

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1033,7 +1033,11 @@ pub trait Visitor<'a> {
             #[cfg(feature = "mysql")]
             FunctionType::UuidToBin => {
                 self.write("uuid_to_bin(uuid())")?;
-            }
+            },
+            #[cfg(feature = "mysql")]
+            FunctionType::UuidToBinSwapped => {
+                self.write("uuid_to_bin(uuid(), 1)")?;
+            },
             #[cfg(feature = "mysql")]
             FunctionType::Uuid => self.write("uuid()")?,
         };

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1033,11 +1033,11 @@ pub trait Visitor<'a> {
             #[cfg(feature = "mysql")]
             FunctionType::UuidToBin => {
                 self.write("uuid_to_bin(uuid())")?;
-            },
+            }
             #[cfg(feature = "mysql")]
             FunctionType::UuidToBinSwapped => {
                 self.write("uuid_to_bin(uuid(), 1)")?;
-            },
+            }
             #[cfg(feature = "mysql")]
             FunctionType::Uuid => self.write("uuid()")?,
         };


### PR DESCRIPTION
 - MySQL 8 has a "fantastic" feature for index-optimized UUIDs, they are called swapped UUIDs
 - Sadly, they are enabled with a parameter in UUID
 - See https://dev.mysql.com/doc/refman/8.0/en/miscellaneous-functions.html#function_uuid-to-bin
 - "Normal" UUID to bin still as is (equivalent parameter, 0)
 - This generates a swapped UUID for generated ids
 - Will solve (partially) https://github.com/prisma/prisma/issues/12850