### PR TITLE
feat: remove query_raw_typed and make it the default

### DIFF
--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -408,10 +408,6 @@ impl Queryable for Mssql {
         .await
     }
 
-    async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
-        self.query_raw(sql, params).await
-    }
-
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
         metrics::query("mssql.execute_raw", sql, params, move || async move {
             let mut query = tiberius::Query::new(sql);
@@ -426,10 +422,6 @@ impl Queryable for Mssql {
             Ok(changes)
         })
         .await
-    }
-
-    async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
-        self.execute_raw(sql, params).await
     }
 
     async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -478,10 +478,6 @@ impl Queryable for Mysql {
         .await
     }
 
-    async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
-        self.query_raw(sql, params).await
-    }
-
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
         metrics::query("mysql.execute_raw", sql, params, move || async move {
             self.prepared(sql, |stmt| async move {
@@ -493,10 +489,6 @@ impl Queryable for Mysql {
             .await
         })
         .await
-    }
-
-    async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
-        self.execute_raw(sql, params).await
     }
 
     async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {

--- a/src/connector/queryable.rs
+++ b/src/connector/queryable.rs
@@ -23,29 +23,12 @@ pub trait Queryable: Send + Sync {
     /// Execute a query given as SQL, interpolating the given parameters.
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet>;
 
-    /// Execute a query given as SQL, interpolating the given parameters.
-    ///
-    /// On Postgres, query parameters types will be inferred from the values
-    /// instead of letting Postgres infer them based on their usage in the SQL query.
-    ///
-    /// NOTE: This method will eventually be removed & merged into Queryable::query_raw().
-    async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet>;
-
     /// Execute the given query, returning the number of affected rows.
     async fn execute(&self, q: Query<'_>) -> crate::Result<u64>;
 
     /// Execute a query given as SQL, interpolating the given parameters and
     /// returning the number of affected rows.
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64>;
-
-    /// Execute a query given as SQL, interpolating the given parameters and
-    /// returning the number of affected rows.
-    ///
-    /// On Postgres, query parameters types will be inferred from the values
-    /// instead of letting Postgres infer them based on their usage in the SQL query.
-    ///
-    /// NOTE: This method will eventually be removed & merged into Queryable::query_raw().
-    async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64>;
 
     /// Run a command in the database, for queries that can't be run using
     /// prepared statements.

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -189,10 +189,6 @@ impl Queryable for Sqlite {
         .await
     }
 
-    async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
-        self.query_raw(sql, params).await
-    }
-
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
         metrics::query("sqlite.query_raw", sql, params, move || async move {
             let client = self.client.lock().await;
@@ -202,10 +198,6 @@ impl Queryable for Sqlite {
             Ok(res)
         })
         .await
-    }
-
-    async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
-        self.execute_raw(sql, params).await
     }
 
     async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {

--- a/src/connector/transaction.rs
+++ b/src/connector/transaction.rs
@@ -56,16 +56,8 @@ impl<'a> Queryable for Transaction<'a> {
         self.inner.query_raw(sql, params).await
     }
 
-    async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
-        self.inner.query_raw_typed(sql, params).await
-    }
-
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
         self.inner.execute_raw(sql, params).await
-    }
-
-    async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
-        self.inner.execute_raw_typed(sql, params).await
     }
 
     async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -34,16 +34,8 @@ impl Queryable for PooledConnection {
         self.inner.query_raw(sql, params).await
     }
 
-    async fn query_raw_typed(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<connector::ResultSet> {
-        self.inner.query_raw_typed(sql, params).await
-    }
-
     async fn execute_raw(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<u64> {
         self.inner.execute_raw(sql, params).await
-    }
-
-    async fn execute_raw_typed(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<u64> {
-        self.inner.execute_raw_typed(sql, params).await
     }
 
     async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {

--- a/src/single.rs
+++ b/src/single.rs
@@ -205,16 +205,8 @@ impl Queryable for Quaint {
         self.inner.query_raw(sql, params).await
     }
 
-    async fn query_raw_typed(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<connector::ResultSet> {
-        self.inner.query_raw_typed(sql, params).await
-    }
-
     async fn execute_raw(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<u64> {
         self.inner.execute_raw(sql, params).await
-    }
-
-    async fn execute_raw_typed(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<u64> {
-        self.inner.execute_raw_typed(sql, params).await
     }
 
     async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -3099,7 +3099,7 @@ async fn generate_native_uuid(api: &mut dyn TestApi) -> crate::Result<()> {
 async fn query_raw_typed_numeric(api: &mut dyn TestApi) -> crate::Result<()> {
     let res = api
         .conn()
-        .query_raw_typed(
+        .query_raw(
             r#"SELECT
                     $1::float4     AS i4tof4,
                     $2::float4     AS i8tof4,
@@ -3166,7 +3166,7 @@ async fn query_raw_typed_date(api: &mut dyn TestApi) -> crate::Result<()> {
 
     let res = api
         .conn()
-        .query_raw_typed(
+        .query_raw(
             r#"SELECT
                     ($1::timestamp - $2::interval)  AS texttointerval,
                     $3 = DATE_PART('year', $4::date) AS is_year_2023;
@@ -3197,7 +3197,7 @@ async fn query_raw_typed_json(api: &mut dyn TestApi) -> crate::Result<()> {
 
     let res = api
         .conn()
-        .query_raw_typed(
+        .query_raw(
             r#"SELECT
                     $1                               as json,
                     $2::text                         as jsontotext,


### PR DESCRIPTION
## Overview

- BREAKING: Remove query_raw_typed and make it the default behaviour via query_raw
- Prisma 4 change