### PR TITLE
Distinction between int32 and int64 in SQLite

### DIFF
--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -286,7 +286,7 @@ mod tests {
         let result = conn.select(select.clone()).await.unwrap();
         let result = result.into_single().unwrap();
 
-        assert_eq!(result.get("id").unwrap(), &Value::integer(1));
+        assert_eq!(result.get("id").unwrap(), &Value::int32(1));
         assert_eq!(result.get("txt").unwrap(), &Value::text("henlo"));
 
         // Check that we do get a separate, new database.

--- a/src/connector/sqlite/conversion.rs
+++ b/src/connector/sqlite/conversion.rs
@@ -133,7 +133,9 @@ impl<'a> GetRow for SqliteRow<'a> {
         for (i, column) in self.columns().iter().enumerate() {
             let pv = match self.get_ref_unwrap(i) {
                 ValueRef::Null => match column {
-                    c if c.is_int32() | c.is_int64() | c.is_null() => Value::Int64(None),
+                    // NOTE: A value without decl_type would be Int32(None)
+                    c if c.is_int32() | c.is_null() => Value::Int32(None),
+                    c if c.is_int64() => Value::Int64(None),
                     c if c.is_text() => Value::Text(None),
                     c if c.is_bytes() => Value::Bytes(None),
                     c if c.is_float() => Value::Float(None),
@@ -152,7 +154,8 @@ impl<'a> GetRow for SqliteRow<'a> {
 
                             return Err(Error::builder(kind).build());
                         }
-                        None => Value::Int64(None),
+                        // When we don't know what to do, the default value would be Int32(None)
+                        None => Value::Int32(None),
                     },
                 },
                 ValueRef::Integer(i) => match column {

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -53,14 +53,8 @@ async fn select_star_from(api: &mut dyn TestApi) -> crate::Result<()> {
     let select = Select::from_table(&table);
     let row = api.conn().select(select).await?.into_single()?;
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Value::int64(4), row["id"]);
-        assert_eq!(Value::int64(3), row["value"]);
-    } else {
-        assert_eq!(Value::int32(4), row["id"]);
-        assert_eq!(Value::int32(3), row["value"]);
-    }
+    assert_eq!(Value::int32(4), row["id"]);
+    assert_eq!(Value::int32(3), row["value"]);
 
     Ok(())
 }
@@ -78,12 +72,7 @@ async fn transactions(api: &mut dyn TestApi) -> crate::Result<()> {
     let select = Select::from_table(&table).column("value");
     let res = api.conn().select(select).await?.into_single()?;
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Value::int64(10), res[0]);
-    } else {
-        assert_eq!(Value::int32(10), res[0]);
-    }
+    assert_eq!(Value::int32(10), res[0]);
 
     tx.rollback().await?;
 
@@ -111,24 +100,13 @@ async fn in_values_singular(api: &mut dyn TestApi) -> crate::Result<()> {
     let res = api.conn().select(query).await?;
     assert_eq!(2, res.len());
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        let row1 = res.get(0).unwrap();
-        assert_eq!(Some(1), row1["id"].as_i64());
-        assert_eq!(Some(2), row1["id2"].as_i64());
+    let row1 = res.get(0).unwrap();
+    assert_eq!(Some(1), row1["id"].as_i32());
+    assert_eq!(Some(2), row1["id2"].as_i32());
 
-        let row2 = res.get(1).unwrap();
-        assert_eq!(Some(3), row2["id"].as_i64());
-        assert_eq!(Some(4), row2["id2"].as_i64());
-    } else {
-        let row1 = res.get(0).unwrap();
-        assert_eq!(Some(1), row1["id"].as_i32());
-        assert_eq!(Some(2), row1["id2"].as_i32());
-
-        let row2 = res.get(1).unwrap();
-        assert_eq!(Some(3), row2["id"].as_i32());
-        assert_eq!(Some(4), row2["id2"].as_i32());
-    }
+    let row2 = res.get(1).unwrap();
+    assert_eq!(Some(3), row2["id"].as_i32());
+    assert_eq!(Some(4), row2["id2"].as_i32());
 
     Ok(())
 }
@@ -150,14 +128,8 @@ async fn not_in_values_singular(api: &mut dyn TestApi) -> crate::Result<()> {
     assert_eq!(1, res.len());
 
     let row1 = res.get(0).unwrap();
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(5), row1["id"].as_i64());
-        assert_eq!(Some(6), row1["id2"].as_i64());
-    } else {
-        assert_eq!(Some(5), row1["id"].as_i32());
-        assert_eq!(Some(6), row1["id2"].as_i32());
-    }
+    assert_eq!(Some(5), row1["id"].as_i32());
+    assert_eq!(Some(6), row1["id2"].as_i32());
 
     Ok(())
 }
@@ -179,24 +151,13 @@ async fn in_values_tuple(api: &mut dyn TestApi) -> crate::Result<()> {
     let res = api.conn().select(query).await?;
     assert_eq!(2, res.len());
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        let row1 = res.get(0).unwrap();
-        assert_eq!(Some(1), row1["id"].as_i64());
-        assert_eq!(Some(2), row1["id2"].as_i64());
+    let row1 = res.get(0).unwrap();
+    assert_eq!(Some(1), row1["id"].as_i32());
+    assert_eq!(Some(2), row1["id2"].as_i32());
 
-        let row2 = res.get(1).unwrap();
-        assert_eq!(Some(3), row2["id"].as_i64());
-        assert_eq!(Some(4), row2["id2"].as_i64());
-    } else {
-        let row1 = res.get(0).unwrap();
-        assert_eq!(Some(1), row1["id"].as_i32());
-        assert_eq!(Some(2), row1["id2"].as_i32());
-
-        let row2 = res.get(1).unwrap();
-        assert_eq!(Some(3), row2["id"].as_i32());
-        assert_eq!(Some(4), row2["id2"].as_i32());
-    }
+    let row2 = res.get(1).unwrap();
+    assert_eq!(Some(3), row2["id"].as_i32());
+    assert_eq!(Some(4), row2["id2"].as_i32());
 
     Ok(())
 }
@@ -219,14 +180,8 @@ async fn not_in_values_tuple(api: &mut dyn TestApi) -> crate::Result<()> {
     assert_eq!(1, res.len());
 
     let row = res.get(0).unwrap();
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(5), row["id"].as_i64());
-        assert_eq!(Some(6), row["id2"].as_i64());
-    } else {
-        assert_eq!(Some(5), row["id"].as_i32());
-        assert_eq!(Some(6), row["id2"].as_i32());
-    }
+    assert_eq!(Some(5), row["id"].as_i32());
+    assert_eq!(Some(6), row["id2"].as_i32());
 
     Ok(())
 }
@@ -248,31 +203,16 @@ async fn order_by_ascend(api: &mut dyn TestApi) -> crate::Result<()> {
     assert_eq!(3, res.len());
 
     let row = res.get(0).unwrap();
+    assert_eq!(Some(1), row["id"].as_i32());
+    assert_eq!(Some(2), row["id2"].as_i32());
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(1), row["id"].as_i64());
-        assert_eq!(Some(2), row["id2"].as_i64());
+    let row = res.get(1).unwrap();
+    assert_eq!(Some(3), row["id"].as_i32());
+    assert_eq!(Some(4), row["id2"].as_i32());
 
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(3), row["id"].as_i64());
-        assert_eq!(Some(4), row["id2"].as_i64());
-
-        let row = res.get(2).unwrap();
-        assert_eq!(Some(5), row["id"].as_i64());
-        assert_eq!(Some(6), row["id2"].as_i64());
-    } else {
-        assert_eq!(Some(1), row["id"].as_i32());
-        assert_eq!(Some(2), row["id2"].as_i32());
-
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(3), row["id"].as_i32());
-        assert_eq!(Some(4), row["id2"].as_i32());
-
-        let row = res.get(2).unwrap();
-        assert_eq!(Some(5), row["id"].as_i32());
-        assert_eq!(Some(6), row["id2"].as_i32());
-    }
+    let row = res.get(2).unwrap();
+    assert_eq!(Some(5), row["id"].as_i32());
+    assert_eq!(Some(6), row["id2"].as_i32());
 
     Ok(())
 }
@@ -292,33 +232,17 @@ async fn order_by_descend(api: &mut dyn TestApi) -> crate::Result<()> {
 
     let res = api.conn().select(query).await?;
     assert_eq!(3, res.len());
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(5), row["id"].as_i32());
+    assert_eq!(Some(6), row["id2"].as_i32());
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(5), row["id"].as_i64());
-        assert_eq!(Some(6), row["id2"].as_i64());
+    let row = res.get(1).unwrap();
+    assert_eq!(Some(3), row["id"].as_i32());
+    assert_eq!(Some(4), row["id2"].as_i32());
 
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(3), row["id"].as_i64());
-        assert_eq!(Some(4), row["id2"].as_i64());
-
-        let row = res.get(2).unwrap();
-        assert_eq!(Some(1), row["id"].as_i64());
-        assert_eq!(Some(2), row["id2"].as_i64());
-    } else {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(5), row["id"].as_i32());
-        assert_eq!(Some(6), row["id2"].as_i32());
-
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(3), row["id"].as_i32());
-        assert_eq!(Some(4), row["id2"].as_i32());
-
-        let row = res.get(2).unwrap();
-        assert_eq!(Some(1), row["id"].as_i32());
-        assert_eq!(Some(2), row["id2"].as_i32());
-    }
+    let row = res.get(2).unwrap();
+    assert_eq!(Some(1), row["id"].as_i32());
+    assert_eq!(Some(2), row["id2"].as_i32());
 
     Ok(())
 }
@@ -678,12 +602,7 @@ async fn single_default_value_insert(api: &mut dyn TestApi) -> crate::Result<()>
     assert_eq!(1, res.len());
 
     let row = res.get(0).unwrap();
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(1), row["id"].as_i64());
-    } else {
-        assert_eq!(Some(1), row["id"].as_i32());
-    }
+    assert_eq!(Some(1), row["id"].as_i32());
     assert_eq!(Some("Musti"), row["name"].as_str());
 
     Ok(())
@@ -715,7 +634,7 @@ async fn returning_insert(api: &mut dyn TestApi) -> crate::Result<()> {
     assert_eq!(1, res.len());
 
     let row = res.get(0).unwrap();
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
+    // NOTE: RETURNING statements are 'special', it does not have the decl for the returned type, INT falls into the NONE case, so is int64
     if api.connector_tag().intersects(Tags::SQLITE) {
         assert_eq!(Some(1), row["id"].as_i64());
     } else {
@@ -887,24 +806,13 @@ async fn single_insert_conflict_do_nothing_single_unique(api: &mut dyn TestApi) 
     let res = api.conn().select(Select::from_table(table)).await?;
     assert_eq!(2, res.len());
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i64());
-        assert_eq!(Some("Musti"), row["name"].as_str());
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(1), row["id"].as_i32());
+    assert_eq!(Some("Musti"), row["name"].as_str());
 
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(2), row["id"].as_i64());
-        assert_eq!(Some("Belka"), row["name"].as_str());
-    } else {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i32());
-        assert_eq!(Some("Musti"), row["name"].as_str());
-
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(2), row["id"].as_i32());
-        assert_eq!(Some("Belka"), row["name"].as_str());
-    }
+    let row = res.get(1).unwrap();
+    assert_eq!(Some(2), row["id"].as_i32());
+    assert_eq!(Some("Belka"), row["name"].as_str());
 
     Ok(())
 }
@@ -938,12 +846,8 @@ async fn single_insert_conflict_do_nothing_single_unique_with_default(api: &mut 
     assert_eq!(1, res.len());
 
     let row = res.get(0).unwrap();
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(10), row["id"].as_i64());
-    } else {
-        assert_eq!(Some(10), row["id"].as_i32());
-    }
+    assert_eq!(Some(10), row["id"].as_i32());
+
     assert_eq!(Some("Musti"), row["name"].as_str());
 
     Ok(())
@@ -975,13 +879,7 @@ async fn single_insert_conflict_do_nothing_single_unique_with_autogen_default(
     assert_eq!(1, res.len());
 
     let row = res.get(0).unwrap();
-
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(1), row["id"].as_i64());
-    } else {
-        assert_eq!(Some(1), row["id"].as_i32());
-    }
+    assert_eq!(Some(1), row["id"].as_i32());
     assert_eq!(Some("Naukio"), row["name"].as_str());
 
     Ok(())
@@ -1058,24 +956,13 @@ async fn single_insert_conflict_do_nothing_two_uniques(api: &mut dyn TestApi) ->
     let res = api.conn().select(select).await?;
     assert_eq!(2, res.len());
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i64());
-        assert_eq!(Some("Musti"), row["name"].as_str());
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(1), row["id"].as_i32());
+    assert_eq!(Some("Musti"), row["name"].as_str());
 
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(2), row["id"].as_i64());
-        assert_eq!(Some("Belka"), row["name"].as_str());
-    } else {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i32());
-        assert_eq!(Some("Musti"), row["name"].as_str());
-
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(2), row["id"].as_i32());
-        assert_eq!(Some("Belka"), row["name"].as_str());
-    }
+    let row = res.get(1).unwrap();
+    assert_eq!(Some(2), row["id"].as_i32());
+    assert_eq!(Some("Belka"), row["name"].as_str());
 
     Ok(())
 }
@@ -1117,19 +1004,14 @@ async fn single_insert_conflict_do_nothing_two_uniques_with_default(api: &mut dy
     assert_eq!(1, res.len());
 
     let row = res.get(0).unwrap();
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(1), row["id"].as_i64());
-    } else {
-        assert_eq!(Some(1), row["id"].as_i32());
-    }
+    assert_eq!(Some(1), row["id"].as_i32());
     assert_eq!(Some("Musti"), row["name"].as_str());
 
     Ok(())
 }
 
 #[test_each_connector]
-async fn single_insert_conflict_do_nothing_compoud_unique(api: &mut dyn TestApi) -> crate::Result<()> {
+async fn single_insert_conflict_do_nothing_compound_unique(api: &mut dyn TestApi) -> crate::Result<()> {
     let table_name = api.create_table("id int, name varchar(255)").await?;
     api.create_index(&table_name, "id asc, name asc").await?;
 
@@ -1158,30 +1040,19 @@ async fn single_insert_conflict_do_nothing_compoud_unique(api: &mut dyn TestApi)
     let res = api.conn().select(select).await?;
     assert_eq!(2, res.len());
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i64());
-        assert_eq!(Some("Musti"), row["name"].as_str());
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(1), row["id"].as_i32());
+    assert_eq!(Some("Musti"), row["name"].as_str());
 
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(1), row["id"].as_i64());
-        assert_eq!(Some("Naukio"), row["name"].as_str());
-    } else {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i32());
-        assert_eq!(Some("Musti"), row["name"].as_str());
-
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(1), row["id"].as_i32());
-        assert_eq!(Some("Naukio"), row["name"].as_str());
-    }
+    let row = res.get(1).unwrap();
+    assert_eq!(Some(1), row["id"].as_i32());
+    assert_eq!(Some("Naukio"), row["name"].as_str());
 
     Ok(())
 }
 
 #[test_each_connector]
-async fn single_insert_conflict_do_nothing_compoud_unique_with_default(api: &mut dyn TestApi) -> crate::Result<()> {
+async fn single_insert_conflict_do_nothing_compound_unique_with_default(api: &mut dyn TestApi) -> crate::Result<()> {
     let table_name = api.create_table("id int, name varchar(255) default 'Musti'").await?;
     api.create_index(&table_name, "id asc, name asc").await?;
 
@@ -1208,12 +1079,8 @@ async fn single_insert_conflict_do_nothing_compoud_unique_with_default(api: &mut
     assert_eq!(1, res.len());
 
     let row = res.get(0).unwrap();
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(1), row["id"].as_i64());
-    } else {
-        assert_eq!(Some(1), row["id"].as_i32());
-    }
+    assert_eq!(Some(1), row["id"].as_i32());
+
     assert_eq!(Some("Musti"), row["name"].as_str());
 
     Ok(())
@@ -1246,30 +1113,19 @@ async fn single_insert_conflict_do_nothing_unique_with_autogen(api: &mut dyn Tes
     let res = api.conn().select(select).await?;
     assert_eq!(2, res.len());
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i64());
-        assert_eq!(Some("Musti"), row["name"].as_str());
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(1), row["id"].as_i32());
+    assert_eq!(Some("Musti"), row["name"].as_str());
 
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(2), row["id"].as_i64());
-        assert_eq!(Some("Naukio"), row["name"].as_str());
-    } else {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i32());
-        assert_eq!(Some("Musti"), row["name"].as_str());
-
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(2), row["id"].as_i32());
-        assert_eq!(Some("Naukio"), row["name"].as_str());
-    }
+    let row = res.get(1).unwrap();
+    assert_eq!(Some(2), row["id"].as_i32());
+    assert_eq!(Some("Naukio"), row["name"].as_str());
 
     Ok(())
 }
 
 #[test_each_connector]
-async fn single_insert_conflict_do_nothing_compoud_unique_with_autogen_default(
+async fn single_insert_conflict_do_nothing_compound_unique_with_autogen_default(
     api: &mut dyn TestApi,
 ) -> crate::Result<()> {
     let table_name = api
@@ -1300,24 +1156,13 @@ async fn single_insert_conflict_do_nothing_compoud_unique_with_autogen_default(
     let res = api.conn().select(select).await?;
     assert_eq!(2, res.len());
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i64());
-        assert_eq!(Some("Musti"), row["name"].as_str());
+    let row = res.get(0).unwrap();
+    assert_eq!(Some(1), row["id"].as_i32());
+    assert_eq!(Some("Musti"), row["name"].as_str());
 
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(2), row["id"].as_i64());
-        assert_eq!(Some("Musti"), row["name"].as_str());
-    } else {
-        let row = res.get(0).unwrap();
-        assert_eq!(Some(1), row["id"].as_i32());
-        assert_eq!(Some("Musti"), row["name"].as_str());
-
-        let row = res.get(1).unwrap();
-        assert_eq!(Some(2), row["id"].as_i32());
-        assert_eq!(Some("Musti"), row["name"].as_str());
-    }
+    let row = res.get(1).unwrap();
+    assert_eq!(Some(2), row["id"].as_i32());
+    assert_eq!(Some("Musti"), row["name"].as_str());
 
     Ok(())
 }
@@ -1339,12 +1184,7 @@ async fn updates(api: &mut dyn TestApi) -> crate::Result<()> {
     assert_eq!(1, res.len());
 
     let row = res.get(0).unwrap();
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(1), row["id"].as_i64());
-    } else {
-        assert_eq!(Some(1), row["id"].as_i32());
-    }
+    assert_eq!(Some(1), row["id"].as_i32());
     assert_eq!(Some("Naukio"), row["name"].as_str());
 
     Ok(())
@@ -1810,7 +1650,7 @@ async fn single_common_table_expression(api: &mut dyn TestApi) -> crate::Result<
     if api.connector_tag().intersects(Tags::POSTGRES) {
         assert_eq!(Some(&Value::text("1")), row.at(0));
     } else if api.connector_tag().intersects(Tags::SQLITE) {
-        // TODO: Make SQLite expect i32 once we differentiate i32 from i64
+        // NOTE: with explicit values, SQLite does not pass the specific declaration type, so is assumed int64
         assert_eq!(Some(&Value::int64(1)), row.at(0));
     } else {
         assert_eq!(Some(&Value::int32(1)), row.at(0));
@@ -1845,7 +1685,7 @@ async fn multiple_common_table_expressions(api: &mut dyn TestApi) -> crate::Resu
         assert_eq!(Some(&Value::text("1")), row.at(0));
         assert_eq!(Some(&Value::text("2")), row.at(1));
     } else if api.connector_tag().intersects(Tags::SQLITE) {
-        // TODO: Make SQLite expect i32 once we differentiate i32 from i64
+        // NOTE: with explicit values, SQLite does not pass the specific declaration type, so is assumed int64
         assert_eq!(Some(&Value::int64(1)), row.at(0));
         assert_eq!(Some(&Value::int64(2)), row.at(1));
     } else {
@@ -2001,14 +1841,8 @@ async fn join_with_compound_columns(api: &mut dyn TestApi) -> crate::Result<()> 
 
     let row = res.get(0).unwrap();
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(&Value::int64(1)), row.at(0));
-        assert_eq!(Some(&Value::int64(2)), row.at(1));
-    } else {
-        assert_eq!(Some(&Value::int32(1)), row.at(0));
-        assert_eq!(Some(&Value::int32(2)), row.at(1));
-    }
+    assert_eq!(Some(&Value::int32(1)), row.at(0));
+    assert_eq!(Some(&Value::int32(2)), row.at(1));
 
     Ok(())
 }
@@ -2049,14 +1883,8 @@ async fn join_with_non_matching_compound_columns(api: &mut dyn TestApi) -> crate
 
     let row = res.get(0).unwrap();
 
-    // TODO: Make SQLite expect i32 once we differentiate i32 from i64
-    if api.connector_tag().intersects(Tags::SQLITE) {
-        assert_eq!(Some(&Value::int64(2)), row.at(0));
-        assert_eq!(Some(&Value::int64(3)), row.at(1));
-    } else {
-        assert_eq!(Some(&Value::int32(2)), row.at(0));
-        assert_eq!(Some(&Value::int32(3)), row.at(1));
-    }
+    assert_eq!(Some(&Value::int32(2)), row.at(0));
+    assert_eq!(Some(&Value::int32(3)), row.at(1));
 
     Ok(())
 }

--- a/src/tests/types/sqlite.rs
+++ b/src/tests/types/sqlite.rs
@@ -16,9 +16,14 @@ test_type!(integer(
     Value::int32(i16::MAX),
     Value::int32(i32::MIN),
     Value::int32(i32::MAX),
+));
+
+test_type!(big_int(
+    sqlite,
+    "BIGINT",
     Value::Int64(None),
     Value::int64(i64::MIN),
-    Value::int64(i64::MAX)
+    Value::int64(i64::MAX),
 ));
 
 #[cfg(feature = "bigdecimal")]

--- a/src/tests/types/sqlite.rs
+++ b/src/tests/types/sqlite.rs
@@ -6,18 +6,17 @@ use crate::{ast::*, connector::Queryable};
 #[cfg(feature = "bigdecimal")]
 use std::str::FromStr;
 
-// TODO: This should return Int32
-// Blocked by: https://github.com/prisma/prisma/issues/12784, which we'll fix for Prisma4
 test_type!(integer(
     sqlite,
     "INTEGER",
+    Value::Int32(None),
+    Value::int32(i8::MIN),
+    Value::int32(i8::MAX),
+    Value::int32(i16::MIN),
+    Value::int32(i16::MAX),
+    Value::int32(i32::MIN),
+    Value::int32(i32::MAX),
     Value::Int64(None),
-    Value::int64(i8::MIN),
-    Value::int64(i8::MAX),
-    Value::int64(i16::MIN),
-    Value::int64(i16::MAX),
-    Value::int64(i32::MIN),
-    Value::int64(i32::MAX),
     Value::int64(i64::MIN),
     Value::int64(i64::MAX)
 ));


### PR DESCRIPTION
- This is part of https://github.com/prisma/prisma/issues/12784
- Now, `INT` is `int32` and `BIGINT` is `int64` in SQLite
- When _we don't know what type is it_ we are now `int32(None)` (this happens with `NULL` types), used to be `int64(None)`
- Certain operations, for example, `RETURNING` cannot infer the return type, in cases where we cannot infer the return type for an integer it will be set as `int64` (another example is with implicit values)
