### PR TITLE
Use OpenSSL instead of rustls on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,15 +127,15 @@ features = ["bundled"]
 optional = true
 
 [target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies.tiberius]
-version = "0.9.0"
+version = "0.9.2"
 optional = true
 features = ["sql-browser-tokio", "chrono", "bigdecimal"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.tiberius]
-version = "0.9.0"
+version = "0.9.2"
 optional = true
 default-features = false
-features = ["sql-browser-tokio", "rustls", "chrono", "bigdecimal", "tds73", "winauth"]
+features = ["sql-browser-tokio", "vendored-openssl", "chrono", "bigdecimal", "tds73", "winauth"]
 
 [dependencies.bigdecimal_]
 version = "0.2.0"


### PR DESCRIPTION
Part of https://github.com/prisma/prisma/issues/13371, https://github.com/prisma/prisma/issues/13372 and https://github.com/prisma/prisma/issues/13522