### PR TITLE
`integer` means `int32` not `int64`

### DIFF
--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -225,9 +225,9 @@ impl<'a> Value<'a> {
     /// Creates a new 64-bit signed integer.
     pub fn integer<I>(value: I) -> Self
     where
-        I: Into<i64>,
+        I: Into<i32>,
     {
-        Value::Int64(Some(value.into()))
+        Value::Int32(Some(value.into()))
     }
 
     /// Creates a new decimal value.

--- a/src/tests/types/postgres.rs
+++ b/src/tests/types/postgres.rs
@@ -108,7 +108,9 @@ test_type!(float8_array(
     Value::array(vec![Value::double(1.1234), Value::double(4.321), Value::Double(None)])
 ));
 
-test_type!(oid(postgresql, "oid", Value::Int64(None), Value::integer(10000)));
+// NOTE: OIDs are unsigned 4 byte integers, see https://www.postgresql.org/docs/9.4/datatype-oid.html
+// but a u32 cannot fit in i32, so we use i64
+test_type!(oid(postgresql, "oid", Value::Int64(None), Value::int64(10000)));
 
 test_type!(oid_array(
     postgresql,

--- a/src/visitor/mssql.rs
+++ b/src/visitor/mssql.rs
@@ -1108,7 +1108,8 @@ mod tests {
         let (sql, params) = Mssql::build(query).unwrap();
 
         assert_eq!(expected_sql, sql);
-        assert_eq!(vec![Value::integer(10)], params);
+        // NOTE: Offsets are unsigned, so they only fit in i64, not i32
+        assert_eq!(vec![Value::int64(10)], params);
     }
 
     #[test]
@@ -1122,7 +1123,8 @@ mod tests {
         let (sql, params) = Mssql::build(query).unwrap();
 
         assert_eq!(expected_sql, sql);
-        assert_eq!(vec![Value::integer(10), Value::integer(9)], params);
+        // NOTE: offset and limits cannot be negative, they are u32, so they fit in i64
+        assert_eq!(vec![Value::int64(10), Value::int64(9)], params);
     }
 
     #[test]
@@ -1132,7 +1134,7 @@ mod tests {
         let (sql, params) = Mssql::build(query).unwrap();
 
         assert_eq!(expected_sql, sql);
-        assert_eq!(vec![Value::integer(10), Value::integer(9)], params);
+        assert_eq!(vec![Value::int64(10), Value::int64(9)], params);
     }
 
     #[test]

--- a/src/visitor/mysql.rs
+++ b/src/visitor/mysql.rs
@@ -38,7 +38,8 @@ impl<'a> Mysql<'a> {
                 serde_json::Value::String(str) => Ok(Value::text(str)),
                 serde_json::Value::Number(number) => {
                     if let Some(int) = number.as_i64() {
-                        Ok(Value::integer(int))
+                        // NOTE: JS numbers are 64bit numbers
+                        Ok(Value::int64(int))
                     } else if let Some(float) = number.as_f64() {
                         Ok(Value::double(float))
                     } else {


### PR DESCRIPTION
- As part of https://github.com/prisma/prisma-engines/pull/2970 we need to make a difference between `i32` and `i64` values in SQLite.
- In the past, we have `integer` as a "shortcut" for `int64` but this is not really the case, every db out there defines `int` as a 32 bit integer, not 64 bit.
- Because of this, a few tests and results need to be fixed:
  * OIDs return an unsigned 32 integer but this does not fit in `i32` so we return `i64` in this case.
  * Certain parameters, like `OFFSET` and `LIMIT`, are too unsigned integers, doing the same, explicitly using `i64`
- Adjusted some tests to reflect this