### PR TITLE
fix: make impl block importing uuid conditional on uuid feature flag

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -363,6 +363,7 @@ impl From<std::net::AddrParseError> for Error {
     }
 }
 
+#[cfg(feature = "uuid")]
 impl From<uuid::Error> for Error {
     fn from(e: uuid::Error) -> Self {
         Error::builder(ErrorKind::UUIDError(format!("{}", e))).build()


### PR DESCRIPTION
Make the impl for `From<uuid::Error> for Error` conditional on uuid feature flag being enabled.

Due to this bug `quiant` doesn't currently compile if the `uuid` feature flag is disabled.