### PR TITLE
add trace around query

### DIFF
--- a/src/connector/metrics.rs
+++ b/src/connector/metrics.rs
@@ -17,7 +17,6 @@ where
     let start = Instant::now();
     let res = f().instrument(span).await;
 
-
     let result = match res {
         Ok(_) => "success",
         Err(_) => "error",

--- a/src/connector/metrics.rs
+++ b/src/connector/metrics.rs
@@ -13,7 +13,7 @@ where
     F: FnOnce() -> U + 'a,
     U: Future<Output = crate::Result<T>>,
 {
-    let span = info_span!("quaint:query", query = %query, user_facing = true);
+    let span = info_span!("quaint:query", "db.statement" = %query, user_facing = true);
     let start = Instant::now();
     let res = f().instrument(span).await;
 

--- a/src/connector/metrics.rs
+++ b/src/connector/metrics.rs
@@ -13,7 +13,7 @@ where
     F: FnOnce() -> U + 'a,
     U: Future<Output = crate::Result<T>>,
 {
-    let span = info_span!("quaint:query", "db.statement" = %query, user_facing = true);
+    let span = info_span!("quaint:query", "db.statement" = %query);
     let start = Instant::now();
     let res = f().instrument(span).await;
 

--- a/src/connector/metrics.rs
+++ b/src/connector/metrics.rs
@@ -1,3 +1,5 @@
+use tracing::{info_span, Instrument};
+
 use crate::ast::{Params, Value};
 use std::{future::Future, time::Instant};
 
@@ -11,8 +13,10 @@ where
     F: FnOnce() -> U + 'a,
     U: Future<Output = crate::Result<T>>,
 {
+    let span = info_span!("quaint:query", query = %query, user_facing = true);
     let start = Instant::now();
-    let res = f().await;
+    let res = f().instrument(span).await;
+
 
     let result = match res {
         Ok(_) => "success",


### PR DESCRIPTION
Creates a tracing span for a database query. It will include the query as part of the tags. example:
<img width="1772" alt="Screenshot 2022-07-07 at 17 07 20" src="https://user-images.githubusercontent.com/179458/177807495-2b1298b0-05e4-4c34-bb9b-0b260911d533.png">

