### PR TITLE
Allow setting Tx isolation on Tx start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     image: mysql:5.7
     command: mysqld
     restart: always
+    platform: linux/x86_64
     environment:
       MYSQL_ROOT_PASSWORD: prisma
       MYSQL_DATABASE: prisma
@@ -30,6 +31,7 @@ services:
     image: mysql:8.0.22
     command: mysqld
     restart: always
+    platform: linux/x86_64
     environment:
       MYSQL_USER: root
       MYSQL_ROOT_PASSWORD: prisma

--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -95,7 +95,7 @@ impl TransactionCapable for Mssql {
     async fn start_transaction(&self, isolation: Option<IsolationLevel>) -> crate::Result<Transaction<'_>> {
         // Isolation levels in SQL Server are set on the connection and live until they're changed.
         // Always explicitly setting the isolation level each time a tx is started (either to the given value
-        // or by using the default/connection string value) prevents transaction started on connection from
+        // or by using the default/connection string value) prevents transactions started on connections from
         // the pool to have unexpected isolation levels set.
         Transaction::new(
             self,

--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -97,15 +97,11 @@ impl TransactionCapable for Mssql {
         // Always explicitly setting the isolation level each time a tx is started (either to the given value
         // or by using the default/connection string value) prevents transactions started on connections from
         // the pool to have unexpected isolation levels set.
-        Transaction::new(
-            self,
-            "BEGIN TRAN",
-            isolation
-                .or_else(|| self.url.query_params.transaction_isolation_level)
-                .or_else(|| Some(SQL_SERVER_DEFAULT_ISOLATION)),
-            self.requires_isolation_first(),
-        )
-        .await
+        let isolation = isolation
+            .or(self.url.query_params.transaction_isolation_level)
+            .or(Some(SQL_SERVER_DEFAULT_ISOLATION));
+
+        Transaction::new(self, "BEGIN TRAN", isolation, self.requires_isolation_first()).await
     }
 }
 

--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -1,7 +1,7 @@
 mod conversion;
 mod error;
 
-use super::IsolationLevel;
+use super::{IsolationLevel, TransactionOptions};
 use crate::{
     ast::{Query, Value},
     connector::{metrics, queryable::*, ResultSet, Transaction},
@@ -101,7 +101,9 @@ impl TransactionCapable for Mssql {
             .or(self.url.query_params.transaction_isolation_level)
             .or(Some(SQL_SERVER_DEFAULT_ISOLATION));
 
-        Transaction::new(self, "BEGIN TRAN", isolation, self.requires_isolation_first()).await
+        let opts = TransactionOptions::new(isolation, self.requires_isolation_first());
+
+        Transaction::new(self, "BEGIN TRAN", opts).await
     }
 }
 

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -1,6 +1,12 @@
 mod conversion;
 mod error;
 
+use crate::{
+    ast::{Query, Value},
+    connector::{metrics, queryable::*, ResultSet},
+    error::{Error, ErrorKind},
+    visitor::{self, Visitor},
+};
 use async_trait::async_trait;
 use lru_cache::LruCache;
 use mysql_async::{
@@ -18,17 +24,12 @@ use std::{
 use tokio::sync::Mutex;
 use url::Url;
 
-use crate::{
-    ast::{Query, Value},
-    connector::{metrics, queryable::*, ResultSet},
-    error::{Error, ErrorKind},
-    visitor::{self, Visitor},
-};
-
 /// The underlying MySQL driver. Only available with the `expose-drivers`
 /// Cargo feature.
 #[cfg(feature = "expose-drivers")]
 pub use mysql_async;
+
+use super::IsolationLevel;
 
 /// A connector interface for the MySQL database.
 #[derive(Debug)]
@@ -448,11 +449,6 @@ impl Queryable for Mysql {
         self.query_raw(&sql, &params).await
     }
 
-    async fn execute(&self, q: Query<'_>) -> crate::Result<u64> {
-        let (sql, params) = visitor::Mysql::build(q)?;
-        self.execute_raw(&sql, &params).await
-    }
-
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
         metrics::query("mysql.query_raw", sql, params, move || async move {
             self.prepared(sql, |stmt| async move {
@@ -480,6 +476,11 @@ impl Queryable for Mysql {
 
     async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
         self.query_raw(sql, params).await
+    }
+
+    async fn execute(&self, q: Query<'_>) -> crate::Result<u64> {
+        let (sql, params) = visitor::Mysql::build(q)?;
+        self.execute_raw(&sql, &params).await
     }
 
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
@@ -534,6 +535,17 @@ impl Queryable for Mysql {
 
     fn is_healthy(&self) -> bool {
         self.is_healthy.load(Ordering::SeqCst)
+    }
+
+    async fn set_tx_isolation_level(&self, isolation_level: IsolationLevel) -> crate::Result<()> {
+        if matches!(isolation_level, IsolationLevel::Snapshot) {
+            return Err(Error::builder(ErrorKind::invalid_isolation_level(&isolation_level)).build());
+        }
+
+        self.raw_cmd(&format!("SET TRANSACTION ISOLATION LEVEL {}", isolation_level))
+            .await?;
+
+        Ok(())
     }
 }
 

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -547,6 +547,10 @@ impl Queryable for Mysql {
 
         Ok(())
     }
+
+    fn requires_isolation_first(&self) -> bool {
+        true
+    }
 }
 
 #[cfg(test)]

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -31,6 +31,8 @@ pub(crate) const DEFAULT_SCHEMA: &str = "public";
 #[cfg(feature = "expose-drivers")]
 pub use tokio_postgres;
 
+use super::IsolationLevel;
+
 #[derive(Clone)]
 struct Hidden<T>(T);
 
@@ -624,12 +626,6 @@ impl Queryable for PostgreSql {
         self.query_raw(sql.as_str(), &params[..]).await
     }
 
-    async fn execute(&self, q: Query<'_>) -> crate::Result<u64> {
-        let (sql, params) = visitor::Postgres::build(q)?;
-
-        self.execute_raw(sql.as_str(), &params[..]).await
-    }
-
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
         metrics::query("postgres.query_raw", sql, params, move || async move {
             let stmt = self.fetch_cached(sql, &[]).await?;
@@ -684,6 +680,12 @@ impl Queryable for PostgreSql {
             Ok(result)
         })
         .await
+    }
+
+    async fn execute(&self, q: Query<'_>) -> crate::Result<u64> {
+        let (sql, params) = visitor::Postgres::build(q)?;
+
+        self.execute_raw(sql.as_str(), &params[..]).await
     }
 
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
@@ -749,6 +751,10 @@ impl Queryable for PostgreSql {
         Ok(version_string)
     }
 
+    fn is_healthy(&self) -> bool {
+        self.is_healthy.load(Ordering::SeqCst)
+    }
+
     async fn server_reset_query(&self, tx: &Transaction<'_>) -> crate::Result<()> {
         if self.pg_bouncer {
             tx.raw_cmd("DEALLOCATE ALL").await
@@ -757,8 +763,15 @@ impl Queryable for PostgreSql {
         }
     }
 
-    fn is_healthy(&self) -> bool {
-        self.is_healthy.load(Ordering::SeqCst)
+    async fn set_tx_isolation_level(&self, isolation_level: IsolationLevel) -> crate::Result<()> {
+        if matches!(isolation_level, IsolationLevel::Snapshot) {
+            return Err(Error::builder(ErrorKind::invalid_isolation_level(&isolation_level)).build());
+        }
+
+        self.raw_cmd(&format!("SET TRANSACTION ISOLATION LEVEL {}", isolation_level))
+            .await?;
+
+        Ok(())
     }
 }
 

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -773,6 +773,10 @@ impl Queryable for PostgreSql {
 
         Ok(())
     }
+
+    fn requires_isolation_first(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/connector/queryable.rs
+++ b/src/connector/queryable.rs
@@ -1,4 +1,4 @@
-use super::{ResultSet, Transaction};
+use super::{IsolationLevel, ResultSet, Transaction};
 use crate::ast::*;
 use async_trait::async_trait;
 
@@ -90,6 +90,10 @@ pub trait Queryable: Send + Sync {
     fn begin_statement(&self) -> &'static str {
         "BEGIN"
     }
+
+    /// Sets the transaction isolation level to given value.
+    /// Implementers have to make sure that the passed isolation level is valid for the underlying database.
+    async fn set_tx_isolation_level(&self, isolation_level: IsolationLevel) -> crate::Result<()>;
 }
 
 /// A thing that can start a new transaction.
@@ -99,7 +103,7 @@ where
     Self: Sized,
 {
     /// Starts a new transaction
-    async fn start_transaction(&self) -> crate::Result<Transaction<'_>> {
-        Transaction::new(self, self.begin_statement()).await
+    async fn start_transaction(&self, isolation: Option<IsolationLevel>) -> crate::Result<Transaction<'_>> {
+        Transaction::new(self, self.begin_statement(), isolation).await
     }
 }

--- a/src/connector/queryable.rs
+++ b/src/connector/queryable.rs
@@ -1,4 +1,4 @@
-use super::{IsolationLevel, ResultSet, Transaction};
+use super::{IsolationLevel, ResultSet, Transaction, TransactionOptions};
 use crate::ast::*;
 use async_trait::async_trait;
 
@@ -107,6 +107,7 @@ where
 {
     /// Starts a new transaction
     async fn start_transaction(&self, isolation: Option<IsolationLevel>) -> crate::Result<Transaction<'_>> {
-        Transaction::new(self, self.begin_statement(), isolation, self.requires_isolation_first()).await
+        let opts = TransactionOptions::new(isolation, self.requires_isolation_first());
+        Transaction::new(self, self.begin_statement(), opts).await
     }
 }

--- a/src/connector/queryable.rs
+++ b/src/connector/queryable.rs
@@ -94,6 +94,9 @@ pub trait Queryable: Send + Sync {
     /// Sets the transaction isolation level to given value.
     /// Implementers have to make sure that the passed isolation level is valid for the underlying database.
     async fn set_tx_isolation_level(&self, isolation_level: IsolationLevel) -> crate::Result<()>;
+
+    /// Signals if the isolation level SET needs to happen before or after the tx BEGIN.
+    fn requires_isolation_first(&self) -> bool;
 }
 
 /// A thing that can start a new transaction.
@@ -104,6 +107,6 @@ where
 {
     /// Starts a new transaction
     async fn start_transaction(&self, isolation: Option<IsolationLevel>) -> crate::Result<Transaction<'_>> {
-        Transaction::new(self, self.begin_statement(), isolation).await
+        Transaction::new(self, self.begin_statement(), isolation, self.requires_isolation_first()).await
     }
 }

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -3,6 +3,7 @@ mod error;
 
 pub use rusqlite::{params_from_iter, version as sqlite_version};
 
+use super::IsolationLevel;
 use crate::{
     ast::{Query, Value},
     connector::{metrics, queryable::*, ResultSet},
@@ -12,8 +13,6 @@ use crate::{
 use async_trait::async_trait;
 use std::{convert::TryFrom, path::Path, time::Duration};
 use tokio::sync::Mutex;
-
-use super::IsolationLevel;
 
 pub(crate) const DEFAULT_SQLITE_SCHEMA_NAME: &str = "main";
 

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -238,6 +238,10 @@ impl Queryable for Sqlite {
 
         Ok(())
     }
+
+    fn requires_isolation_first(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 #[cfg(feature = "pooled")]
 use std::time::Duration;
 
+use crate::connector::IsolationLevel;
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum DatabaseConstraint {
     Fields(Vec<String>),
@@ -243,6 +245,9 @@ pub enum ErrorKind {
     #[error("Transaction was already closed: {}", _0)]
     TransactionAlreadyClosed(String),
 
+    #[error("Invalid isolation level: {}", _0)]
+    InvalidIsolationLevel(String),
+
     #[error("Error creating UUID, {}", _0)]
     UUIDError(String),
 
@@ -275,6 +280,10 @@ impl ErrorKind {
             in_use,
             timeout: timeout.as_secs(),
         }
+    }
+
+    pub(crate) fn invalid_isolation_level(isolation_level: &IsolationLevel) -> Self {
+        Self::InvalidIsolationLevel(isolation_level.to_string())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,10 @@
 //! Error module
+use crate::connector::IsolationLevel;
 use std::{borrow::Cow, fmt, io, num};
 use thiserror::Error;
 
 #[cfg(feature = "pooled")]
 use std::time::Duration;
-
-use crate::connector::IsolationLevel;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DatabaseConstraint {

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -19,11 +19,7 @@ pub struct PooledConnection {
 }
 
 #[async_trait]
-impl TransactionCapable for PooledConnection {
-    async fn start_transaction(&self, isolation: Option<IsolationLevel>) -> crate::Result<Transaction<'_>> {
-        Transaction::new(self, self.begin_statement(), isolation).await
-    }
-}
+impl TransactionCapable for PooledConnection {}
 
 #[async_trait]
 impl Queryable for PooledConnection {
@@ -73,6 +69,10 @@ impl Queryable for PooledConnection {
 
     async fn set_tx_isolation_level(&self, isolation_level: IsolationLevel) -> crate::Result<()> {
         self.inner.set_tx_isolation_level(isolation_level).await
+    }
+
+    fn requires_isolation_first(&self) -> bool {
+        self.inner.requires_isolation_first()
     }
 }
 

--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -18,7 +18,6 @@ pub struct PooledConnection {
     pub(crate) inner: MobcPooled<QuaintManager>,
 }
 
-#[async_trait]
 impl TransactionCapable for PooledConnection {}
 
 #[async_trait]

--- a/src/single.rs
+++ b/src/single.rs
@@ -4,7 +4,7 @@
 use crate::connector::DEFAULT_SQLITE_SCHEMA_NAME;
 use crate::{
     ast,
-    connector::{self, ConnectionInfo, Queryable, TransactionCapable},
+    connector::{self, ConnectionInfo, IsolationLevel, Queryable, TransactionCapable},
 };
 use async_trait::async_trait;
 use std::{fmt, sync::Arc};
@@ -197,16 +197,16 @@ impl Queryable for Quaint {
         self.inner.query(q).await
     }
 
-    async fn execute(&self, q: ast::Query<'_>) -> crate::Result<u64> {
-        self.inner.execute(q).await
-    }
-
     async fn query_raw(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<connector::ResultSet> {
         self.inner.query_raw(sql, params).await
     }
 
     async fn query_raw_typed(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<connector::ResultSet> {
         self.inner.query_raw_typed(sql, params).await
+    }
+
+    async fn execute(&self, q: ast::Query<'_>) -> crate::Result<u64> {
+        self.inner.execute(q).await
     }
 
     async fn execute_raw(&self, sql: &str, params: &[ast::Value<'_>]) -> crate::Result<u64> {
@@ -225,11 +225,15 @@ impl Queryable for Quaint {
         self.inner.version().await
     }
 
+    fn is_healthy(&self) -> bool {
+        self.inner.is_healthy()
+    }
+
     fn begin_statement(&self) -> &'static str {
         self.inner.begin_statement()
     }
 
-    fn is_healthy(&self) -> bool {
-        self.inner.is_healthy()
+    async fn set_tx_isolation_level(&self, isolation_level: IsolationLevel) -> crate::Result<()> {
+        self.inner.set_tx_isolation_level(isolation_level).await
     }
 }

--- a/src/single.rs
+++ b/src/single.rs
@@ -236,4 +236,8 @@ impl Queryable for Quaint {
     async fn set_tx_isolation_level(&self, isolation_level: IsolationLevel) -> crate::Result<()> {
         self.inner.set_tx_isolation_level(isolation_level).await
     }
+
+    fn requires_isolation_first(&self) -> bool {
+        self.inner.requires_isolation_first()
+    }
 }

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -4,7 +4,7 @@ use super::test_api::*;
 #[cfg(all(feature = "json", any(feature = "postgresql", feature = "mysql")))]
 use crate::ast::JsonPath;
 use crate::{
-    connector::{Queryable, TransactionCapable},
+    connector::{IsolationLevel, Queryable, TransactionCapable},
     prelude::*,
 };
 use test_macros::test_each_connector;
@@ -63,7 +63,7 @@ async fn select_star_from(api: &mut dyn TestApi) -> crate::Result<()> {
 async fn transactions(api: &mut dyn TestApi) -> crate::Result<()> {
     let table = api.create_table("value int").await?;
 
-    let tx = api.conn().start_transaction().await?;
+    let tx = api.conn().start_transaction(None).await?;
     let insert = Insert::single_into(&table).value("value", 10);
 
     let rows_affected = tx.execute(insert.into()).await?;
@@ -80,6 +80,60 @@ async fn transactions(api: &mut dyn TestApi) -> crate::Result<()> {
     let res = api.conn().select(select).await?;
 
     assert_eq!(0, res.len());
+
+    Ok(())
+}
+
+#[test_each_connector(tags("mssql", "postgresql", "mysql"))]
+async fn transactions_with_isolation_works(api: &mut dyn TestApi) -> crate::Result<()> {
+    // This test only tests that the SET isolation level statements are accepted.
+    api.conn()
+        .start_transaction(Some(IsolationLevel::ReadUncommitted))
+        .await?
+        .commit()
+        .await?;
+
+    api.conn()
+        .start_transaction(Some(IsolationLevel::ReadCommitted))
+        .await?
+        .commit()
+        .await?;
+
+    api.conn()
+        .start_transaction(Some(IsolationLevel::RepeatableRead))
+        .await?
+        .commit()
+        .await?;
+
+    api.conn()
+        .start_transaction(Some(IsolationLevel::Serializable))
+        .await?
+        .commit()
+        .await?;
+
+    Ok(())
+}
+
+// SQLite only supports serializable.
+#[test_each_connector(tags("sqlite"))]
+async fn sqlite_serializable_tx(api: &mut dyn TestApi) -> crate::Result<()> {
+    api.conn()
+        .start_transaction(Some(IsolationLevel::Serializable))
+        .await?
+        .commit()
+        .await?;
+
+    Ok(())
+}
+
+// Only SQL Server supports snapshot.
+#[test_each_connector(tags("mssql"))]
+async fn mssql_snapshot_tx(api: &mut dyn TestApi) -> crate::Result<()> {
+    api.conn()
+        .start_transaction(Some(IsolationLevel::Snapshot))
+        .await?
+        .commit()
+        .await?;
 
     Ok(())
 }

--- a/src/tests/query/error.rs
+++ b/src/tests/query/error.rs
@@ -419,3 +419,19 @@ async fn array_into_scalar_should_fail(api: &mut dyn TestApi) -> crate::Result<(
 
     Ok(())
 }
+
+// #[test_each_connector(tags("mssql"))]
+// async fn database_already_exists(api: &mut dyn TestApi) -> crate::Result<()> {
+//     let query = "CREATE DATABASE master";
+
+//     let err = api.conn().raw_cmd(query).await.unwrap_err();
+
+//     match err.kind() {
+//         ErrorKind::DatabaseAlreadyExists { db_name } => {
+//             assert_eq!(&Name::available("master"), db_name);
+//         }
+//         e => panic!("Expected error DatabaseAlreadyExists, got {:?}", e),
+//     }
+
+//     Ok(())
+// }


### PR DESCRIPTION
Allows setting an `IsolationLevel` when starting a new transaction. The underlying databases validate what levels of the ANSI + Snapshot levels are appropriate. Additionally, some databases require `SET` of the isolation level before a `BEGIN` of a transaction. 

Functional testing is thin, because it's hard to validate the isolation levels without either:
- Setting up dedicated scenarios for all databases to test.
- Checking that the connection executed the `SET` statement correctly.
- Somehow checking that the isolation level of the connection changed. Difficulty greatly depends on the database provider here. It's unclear if this is feasible for all providers.