### PR TITLE
Implement missing expose-drivers methods (mssql,sqlite)

### DIFF
--- a/src/connector/mssql.rs
+++ b/src/connector/mssql.rs
@@ -312,6 +312,13 @@ impl Mssql {
         Ok(this)
     }
 
+    /// The underlying Tiberius client. Only available with the `expose-drivers` Cargo feature.
+    /// This is a lower level API when you need to get into database specific features.
+    #[cfg(feature = "expose-drivers")]
+    pub fn client(&self) -> &Mutex<Client<Compat<TcpStream>>> {
+        &self.client
+    }
+
     async fn perform_io<F, T>(&self, fut: F) -> crate::Result<T>
     where
         F: Future<Output = std::result::Result<T, tiberius::error::Error>>,

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -158,6 +158,13 @@ impl Sqlite {
             client: Mutex::new(client),
         })
     }
+
+    /// The underlying rusqlite::Connection. Only available with the `expose-drivers` Cargo
+    /// feature. This is a lower level API when you need to get into database specific features.
+    #[cfg(feature = "expose-drivers")]
+    pub fn connection(&self) -> &Mutex<rusqlite::Connection> {
+        &self.client
+    }
 }
 
 impl TransactionCapable for Sqlite {}


### PR DESCRIPTION
These were forgotten in https://github.com/prisma/quaint/pull/387 — this
just brings the feature on sqlite and mssql on parity with what already
exists on postgres and mysql.