### PR TITLE
Display parameters for certain types is done correctly

### DIFF
--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -132,7 +132,7 @@ impl<'a> fmt::Display for Value<'a> {
                 }
                 write!(f, "]")
             }),
-            Value::Xml(val) => val.as_ref().map(|v| write!(f, "\"{}\"", v)),
+            Value::Xml(val) => val.as_ref().map(|v| write!(f, "{}", v)),
             #[cfg(feature = "bigdecimal")]
             Value::Numeric(val) => val.as_ref().map(|v| write!(f, "{}", v)),
             #[cfg(feature = "json")]
@@ -914,6 +914,8 @@ impl<'a> IntoIterator for Values<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bigdecimal_::num_traits::real::Real;
+    use chrono::Date;
     #[cfg(feature = "chrono")]
     use std::str::FromStr;
 
@@ -966,5 +968,41 @@ mod tests {
         let pv = Value::array(vec![1]);
         let rslt: Option<Vec<f64>> = pv.into_vec();
         assert!(rslt.is_none());
+    }
+
+    #[test]
+    #[cfg(feature = "chrono")]
+    fn display_format_for_datetime() {
+        let dt: DateTime<Utc> = DateTime::from_str("2019-07-27T05:30:30Z").expect("failed while parsing date");
+        let pv = Value::datetime(dt);
+
+        assert_eq!(format!("{}", pv), "\"2019-07-27 05:30:30 UTC\"");
+    }
+
+    #[test]
+    #[cfg(feature = "chrono")]
+    fn display_format_for_date() {
+        let date = NaiveDate::from_ymd(2022, 8, 11);
+        let pv = Value::date(date);
+
+        assert_eq!(format!("{}", pv), "\"2022-08-11\"");
+    }
+
+    #[test]
+    #[cfg(feature = "chrono")]
+    fn display_format_for_time() {
+        let time = NaiveTime::from_hms(16, 17, 00);
+        let pv = Value::time(time);
+
+        assert_eq!(format!("{}", pv), "\"16:17:00\"");
+    }
+
+    #[test]
+    #[cfg(feature = "uuid")]
+    fn display_format_for_uuid() {
+        let id = Uuid::from_str("67e5504410b1426f9247bb680e5fe0c8").unwrap();
+        let pv = Value::uuid(id);
+
+        assert_eq!(format!("{}", pv), "\"67e55044-10b1-426f-9247-bb680e5fe0c8\"");
     }
 }

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -132,19 +132,19 @@ impl<'a> fmt::Display for Value<'a> {
                 }
                 write!(f, "]")
             }),
-            Value::Xml(val) => val.as_ref().map(|v| write!(f, "{}", v)),
+            Value::Xml(val) => val.as_ref().map(|v| write!(f, "\"{}\"", v)),
             #[cfg(feature = "bigdecimal")]
             Value::Numeric(val) => val.as_ref().map(|v| write!(f, "{}", v)),
             #[cfg(feature = "json")]
             Value::Json(val) => val.as_ref().map(|v| write!(f, "{}", v)),
             #[cfg(feature = "uuid")]
-            Value::Uuid(val) => val.map(|v| write!(f, "{}", v)),
+            Value::Uuid(val) => val.map(|v| write!(f, "\"{}\"", v)),
             #[cfg(feature = "chrono")]
-            Value::DateTime(val) => val.map(|v| write!(f, "{}", v)),
+            Value::DateTime(val) => val.map(|v| write!(f, "\"{}\"", v)),
             #[cfg(feature = "chrono")]
-            Value::Date(val) => val.map(|v| write!(f, "{}", v)),
+            Value::Date(val) => val.map(|v| write!(f, "\"{}\"", v)),
             #[cfg(feature = "chrono")]
-            Value::Time(val) => val.map(|v| write!(f, "{}", v)),
+            Value::Time(val) => val.map(|v| write!(f, "\"{}\"", v)),
         };
 
         match res {

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -914,8 +914,6 @@ impl<'a> IntoIterator for Values<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bigdecimal_::num_traits::real::Real;
-    use chrono::Date;
     #[cfg(feature = "chrono")]
     use std::str::FromStr;
 


### PR DESCRIPTION
 - Certain types, `Date`, `DateTime`, `Xml`, `UUID`, `Time` are displayed as quoted values in logging messages
 - This is part of fix for https://github.com/prisma/prisma/issues/6578