### PR TITLE
chore: Fix sqlite returning with comment

### DIFF
--- a/src/ast/insert.rs
+++ b/src/ast/insert.rs
@@ -230,7 +230,7 @@ impl<'a> Insert<'a> {
     /// let insert = Insert::from(query).comment("trace_id='5bd66ef5095369c7b0d1f8f4bd33716a', parent_id='c532cb4098ac3dd2'");
     /// let (sql, _) = Sqlite::build(insert)?;
     ///
-    /// assert_eq!("INSERT INTO `users` DEFAULT VALUES /* trace_id='5bd66ef5095369c7b0d1f8f4bd33716a', parent_id='c532cb4098ac3dd2' */", sql);
+    /// assert_eq!("INSERT INTO `users` DEFAULT VALUES; /* trace_id='5bd66ef5095369c7b0d1f8f4bd33716a', parent_id='c532cb4098ac3dd2' */", sql);
     /// # Ok(())
     /// # }
     /// ```

--- a/src/tests/query.rs
+++ b/src/tests/query.rs
@@ -678,7 +678,11 @@ async fn returning_insert(api: &mut dyn TestApi) -> crate::Result<()> {
 
     let res = api
         .conn()
-        .insert(Insert::from(insert).returning(vec!["id", "name"]))
+        .insert(
+            Insert::from(insert)
+                .returning(vec!["id", "name"])
+                .comment("this should be ignored"),
+        )
         .await;
 
     api.conn().raw_cmd(&format!("DROP TABLE {}", table)).await?;

--- a/src/visitor/sqlite.rs
+++ b/src/visitor/sqlite.rs
@@ -211,7 +211,7 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
         }
 
         if let Some(comment) = insert.comment {
-            self.write(" ")?;
+            self.write("; ")?;
             self.visit_comment(comment)?;
         }
 
@@ -766,7 +766,7 @@ mod tests {
 
     #[test]
     fn test_comment_insert() {
-        let expected_sql = "INSERT INTO `users` DEFAULT VALUES /* trace_id='5bd66ef5095369c7b0d1f8f4bd33716a', parent_id='c532cb4098ac3dd2' */";
+        let expected_sql = "INSERT INTO `users` DEFAULT VALUES; /* trace_id='5bd66ef5095369c7b0d1f8f4bd33716a', parent_id='c532cb4098ac3dd2' */";
         let query = Insert::single_into("users");
         let insert =
             Insert::from(query).comment("trace_id='5bd66ef5095369c7b0d1f8f4bd33716a', parent_id='c532cb4098ac3dd2'");


### PR DESCRIPTION
This fixes an insert with a returning statement followed by a comment.
Sqlite needs a `;` to preceed the comment otherwise it adds the
comment as part of the row name.