### PR TITLE
feat(postgres): map 'std::io::ErrorKind::InvalidInput' coming from 'tokio_postgres' to 'quaint::error::ErrorKind::QueryInvalidInput'

### DIFF
--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -642,7 +642,7 @@ impl Queryable for PostgreSql {
     }
 
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
-        self.check_bind_variables_len(&params)?;
+        self.check_bind_variables_len(params)?;
 
         metrics::query("postgres.query_raw", sql, params, move || async move {
             let stmt = self.fetch_cached(sql, &[]).await?;
@@ -672,7 +672,7 @@ impl Queryable for PostgreSql {
     }
 
     async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
-        self.check_bind_variables_len(&params)?;
+        self.check_bind_variables_len(params)?;
 
         metrics::query("postgres.query_raw", sql, params, move || async move {
             let stmt = self.fetch_cached(sql, params).await?;
@@ -708,7 +708,7 @@ impl Queryable for PostgreSql {
     }
 
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
-        self.check_bind_variables_len(&params)?;
+        self.check_bind_variables_len(params)?;
 
         metrics::query("postgres.execute_raw", sql, params, move || async move {
             let stmt = self.fetch_cached(sql, &[]).await?;
@@ -732,7 +732,7 @@ impl Queryable for PostgreSql {
     }
 
     async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
-        self.check_bind_variables_len(&params)?;
+        self.check_bind_variables_len(params)?;
 
         metrics::query("postgres.execute_raw", sql, params, move || async move {
             let stmt = self.fetch_cached(sql, params).await?;

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -599,6 +599,21 @@ impl PostgreSql {
             res => res,
         }
     }
+
+    fn check_bind_variables_len(&self, params: &[Value<'_>]) -> crate::Result<()> {
+        if params.len() > i16::MAX as usize {
+            // tokio_postgres would return an error here. Let's avoid calling the driver
+            // and return an error early.
+            let kind = ErrorKind::QueryInvalidInput(format!(
+                "too many bind variables in prepared statement, expected maximum of {}, received {}",
+                i16::MAX,
+                params.len()
+            ));
+            return Err(Error::builder(kind).build());
+        } else {
+            Ok(())
+        }
+    }
 }
 
 // A SetSearchPath statement (Display-impl) for connection initialization.
@@ -627,6 +642,8 @@ impl Queryable for PostgreSql {
     }
 
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
+        self.check_bind_variables_len(&params)?;
+
         metrics::query("postgres.query_raw", sql, params, move || async move {
             let stmt = self.fetch_cached(sql, &[]).await?;
 
@@ -655,6 +672,8 @@ impl Queryable for PostgreSql {
     }
 
     async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
+        self.check_bind_variables_len(&params)?;
+
         metrics::query("postgres.query_raw", sql, params, move || async move {
             let stmt = self.fetch_cached(sql, params).await?;
 
@@ -689,6 +708,8 @@ impl Queryable for PostgreSql {
     }
 
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
+        self.check_bind_variables_len(&params)?;
+
         metrics::query("postgres.execute_raw", sql, params, move || async move {
             let stmt = self.fetch_cached(sql, &[]).await?;
 
@@ -711,6 +732,8 @@ impl Queryable for PostgreSql {
     }
 
     async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
+        self.check_bind_variables_len(&params)?;
+
         metrics::query("postgres.execute_raw", sql, params, move || async move {
             let stmt = self.fetch_cached(sql, params).await?;
 

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -609,7 +609,7 @@ impl PostgreSql {
                 i16::MAX,
                 params.len()
             ));
-            return Err(Error::builder(kind).build());
+            Err(Error::builder(kind).build())
         } else {
             Ok(())
         }

--- a/src/connector/postgres/error.rs
+++ b/src/connector/postgres/error.rs
@@ -349,7 +349,19 @@ fn try_extracting_io_error(err: &tokio_postgres::error::Error) -> Option<Error> 
 
     err.source()
         .and_then(|err| err.downcast_ref::<std::io::Error>())
-        .map(|err| ErrorKind::ConnectionError(Box::new(std::io::Error::new(err.kind(), format!("{}", err)))))
+        .map(|err| {
+            let inner_io_error = Box::new(std::io::Error::new(err.kind(), format!("{}", err)));
+            match err.kind() {
+                // tokio_postgres will throw `std::io::Error`s with kind `InvalidInput` in several occasions,
+                // e.g., when the number of provided bind variables is >= 32768.
+                // We map these to `quaint::error::ErrorKind::QueryInvalidInput` to avoid confusing user-facing
+                // error messages.
+                std::io::ErrorKind::InvalidInput => ErrorKind::QueryInvalidInput(inner_io_error),
+
+                // fall back to a generic `ConnectionError`
+                _ => ErrorKind::ConnectionError(inner_io_error),
+            }
+        })
         .map(|kind| Error::builder(kind).build())
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -147,7 +147,7 @@ pub enum ErrorKind {
     QueryError(Box<dyn std::error::Error + Send + Sync + 'static>),
 
     #[error("Invalid input provided to query: {}", _0)]
-    QueryInvalidInput(Box<dyn std::error::Error + Send + Sync + 'static>),
+    QueryInvalidInput(String),
 
     #[error("Database does not exist: {}", db_name)]
     DatabaseDoesNotExist { db_name: Name },

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,6 +146,9 @@ pub enum ErrorKind {
     #[error("Error querying the database: {}", _0)]
     QueryError(Box<dyn std::error::Error + Send + Sync + 'static>),
 
+    #[error("Invalid input provided to query: {}", _0)]
+    QueryInvalidInput(Box<dyn std::error::Error + Send + Sync + 'static>),
+
     #[error("Database does not exist: {}", db_name)]
     DatabaseDoesNotExist { db_name: Name },
 


### PR DESCRIPTION
Context: https://www.notion.so/prismaio/Postgres-parameters-length-validation-ffc127b887984e02b9d931fcec4d6d15#62014932a75e438e9eb07306aee43224

Allows fixes to https://prisma/prisma/issues/8832 and https://prisma/prisma/issues/9326.