### PR TITLE
fix(mysql): unsigned ints should be coerced as i64

### DIFF
--- a/src/connector/mysql/conversion.rs
+++ b/src/connector/mysql/conversion.rs
@@ -108,30 +108,36 @@ impl TypeIdentifier for my::Column {
     fn is_int32(&self) -> bool {
         use ColumnType::*;
 
+        let is_unsigned = self.flags().intersects(ColumnFlags::UNSIGNED_FLAG);
+
         // https://dev.mysql.com/doc/internals/en/binary-protocol-value.html#packet-ProtocolBinary
         // MYSQL_TYPE_TINY  = i8
         // MYSQL_TYPE_SHORT = i16
         // MYSQL_TYPE_YEAR  = i16
-        // MYSQL_TYPE_LONG  = i32
-        // MYSQL_TYPE_INT24 = i32
+        // SIGNED MYSQL_TYPE_LONG  = i32
+        // SIGNED MYSQL_TYPE_INT24 = i32
         matches!(
-            self.column_type(),
-            MYSQL_TYPE_TINY | MYSQL_TYPE_SHORT | MYSQL_TYPE_YEAR | MYSQL_TYPE_LONG | MYSQL_TYPE_INT24
+            (self.column_type(), is_unsigned),
+            (MYSQL_TYPE_TINY, _)
+                | (MYSQL_TYPE_SHORT, _)
+                | (MYSQL_TYPE_YEAR, _)
+                | (MYSQL_TYPE_LONG, false)
+                | (MYSQL_TYPE_INT24, false)
         )
     }
 
     fn is_int64(&self) -> bool {
         use ColumnType::*;
 
+        let is_unsigned = self.flags().intersects(ColumnFlags::UNSIGNED_FLAG);
+
         // https://dev.mysql.com/doc/internals/en/binary-protocol-value.html#packet-ProtocolBinary
         // MYSQL_TYPE_LONGLONG = i64
         // UNSIGNED MYSQL_TYPE_LONG = u32
         // UNSIGNED MYSQL_TYPE_INT24 = u32
         matches!(
-            (self.column_type(), self.flags()),
-            (MYSQL_TYPE_LONGLONG, _)
-                | (MYSQL_TYPE_LONG, ColumnFlags::UNSIGNED_FLAG)
-                | (MYSQL_TYPE_INT24, ColumnFlags::UNSIGNED_FLAG)
+            (self.column_type(), is_unsigned),
+            (MYSQL_TYPE_LONGLONG, _) | (MYSQL_TYPE_LONG, true) | (MYSQL_TYPE_INT24, true)
         )
     }
 

--- a/src/tests/types/mysql.rs
+++ b/src/tests/types/mysql.rs
@@ -83,6 +83,15 @@ test_type!(int_unsigned(
     "int unsigned",
     Value::Int64(None),
     Value::int64(0),
+    Value::int64(2173158296i64),
+    Value::int64(4294967295i64)
+));
+
+test_type!(int_unsigned_not_null(
+    mysql,
+    "int unsigned not null",
+    Value::int64(0),
+    Value::int64(2173158296i64),
     Value::int64(4294967295i64)
 ));
 


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/15264
follow-up QE PR: https://github.com/prisma/prisma-engines/pull/3233

The match on `ColumnFlags::UNSIGNED_FLAG` would only work if `UNSIGNED_FLAG` was the only flag set.
If any other flag were set, such as the `NOT_NULL` flag, then it wouldn't match and the value would thus be coerced as an `i32` instead. In the case of a u32, it would overflow, leading to upsert issues in the QE (and probably more issues).