### PR TITLE
Cargo.toml: delete native-tls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ vendored-openssl = [
 ]
 
 postgresql = [
-  "native-tls",
   "tokio-postgres",
   "postgres-types",
   "postgres-native-tls",
@@ -87,7 +86,6 @@ base64 = { version = "0.12.3", optional = true }
 chrono = { version = "0.4", optional = true }
 lru-cache = { version = "0.1", optional = true }
 serde_json = { version = "1.0.48", optional = true, features = ["float_roundtrip"] }
-native-tls = { version = "0.2", optional = true }
 bit-vec = { version = "0.6.1", optional = true }
 bytes = { version = "1.0", optional = true }
 mobc = { git = "https://github.com/prisma/mobc",  tag = "1.0.6", optional = true }


### PR DESCRIPTION
It is transitively through tokio-postgres, but not in this crate.