### PR TITLE
Cargo.toml: depend on more minimal chrono feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ hex = "0.4"
 
 either = { version = "1.6", optional = true }
 base64 = { version = "0.12.3", optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", optional = true, default-features = false }
 lru-cache = { version = "0.1", optional = true }
 serde_json = { version = "1.0.48", optional = true, features = ["float_roundtrip"] }
 native-tls = { version = "0.2", optional = true }

--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -980,7 +980,7 @@ mod tests {
     #[test]
     #[cfg(feature = "chrono")]
     fn display_format_for_date() {
-        let date = NaiveDate::from_ymd(2022, 8, 11);
+        let date = NaiveDate::from_ymd_opt(2022, 8, 11).unwrap();
         let pv = Value::date(date);
 
         assert_eq!(format!("{}", pv), "\"2022-08-11\"");

--- a/src/connector/mysql/conversion.rs
+++ b/src/connector/mysql/conversion.rs
@@ -287,9 +287,9 @@ impl TakeRow for my::Row {
                         return Err(Error::builder(kind).build());
                     }
 
-                    let time = NaiveTime::from_hms_micro(hour.into(), min.into(), sec.into(), micro);
+                    let time = NaiveTime::from_hms_micro_opt(hour.into(), min.into(), sec.into(), micro).unwrap();
 
-                    let date = NaiveDate::from_ymd(year.into(), month.into(), day.into());
+                    let date = NaiveDate::from_ymd_opt(year.into(), month.into(), day.into()).unwrap();
                     let dt = NaiveDateTime::new(date, time);
 
                     Value::datetime(DateTime::<Utc>::from_utc(dt, Utc))
@@ -306,7 +306,7 @@ impl TakeRow for my::Row {
                         return Err(Error::builder(kind).build());
                     }
 
-                    let time = NaiveTime::from_hms_micro(hours.into(), minutes.into(), seconds.into(), micros);
+                    let time = NaiveTime::from_hms_micro_opt(hours.into(), minutes.into(), seconds.into(), micros).unwrap();
                     Value::time(time)
                 }
                 my::Value::NULL => match column {

--- a/src/connector/mysql/conversion.rs
+++ b/src/connector/mysql/conversion.rs
@@ -306,7 +306,8 @@ impl TakeRow for my::Row {
                         return Err(Error::builder(kind).build());
                     }
 
-                    let time = NaiveTime::from_hms_micro_opt(hours.into(), minutes.into(), seconds.into(), micros).unwrap();
+                    let time =
+                        NaiveTime::from_hms_micro_opt(hours.into(), minutes.into(), seconds.into(), micros).unwrap();
                     Value::time(time)
                 }
                 my::Value::NULL => match column {

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -898,7 +898,7 @@ impl<'a> ToSql for Value<'a> {
                 (Value::Uuid(value), _) => value.map(|value| value.to_sql(ty, out)),
                 #[cfg(feature = "chrono")]
                 (Value::DateTime(value), &PostgresType::DATE) => {
-                    value.map(|value| value.date().naive_utc().to_sql(ty, out))
+                    value.map(|value| value.date_naive().to_sql(ty, out))
                 }
                 #[cfg(feature = "chrono")]
                 (Value::Date(value), _) => value.map(|value| value.to_sql(ty, out)),

--- a/src/connector/postgres/conversion.rs
+++ b/src/connector/postgres/conversion.rs
@@ -897,9 +897,7 @@ impl<'a> ToSql for Value<'a> {
                 #[cfg(feature = "uuid")]
                 (Value::Uuid(value), _) => value.map(|value| value.to_sql(ty, out)),
                 #[cfg(feature = "chrono")]
-                (Value::DateTime(value), &PostgresType::DATE) => {
-                    value.map(|value| value.date_naive().to_sql(ty, out))
-                }
+                (Value::DateTime(value), &PostgresType::DATE) => value.map(|value| value.date_naive().to_sql(ty, out)),
                 #[cfg(feature = "chrono")]
                 (Value::Date(value), _) => value.map(|value| value.to_sql(ty, out)),
                 #[cfg(feature = "chrono")]


### PR DESCRIPTION
Disable the default features. Specifically so that wasm-bindgen won't be included if not necessary, as it is a rather intrusive library.