### PR TITLE
added missing #[cfg(feature = "uuid")]

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -380,6 +380,7 @@ impl From<std::net::AddrParseError> for Error {
     }
 }
 
+#[cfg(feature = "uuid")]
 impl From<uuid::Error> for Error {
     fn from(e: uuid::Error) -> Self {
         Error::builder(ErrorKind::UUIDError(format!("{}", e))).build()


### PR DESCRIPTION
one liner, found it by forgetting to enable uuid feature.