### PR TITLE
Add PooledConnection::manager()

### DIFF
--- a/src/pooled/manager.rs
+++ b/src/pooled/manager.rs
@@ -18,6 +18,13 @@ pub struct PooledConnection {
     pub(crate) inner: MobcPooled<QuaintManager>,
 }
 
+impl PooledConnection {
+    /// The connection's pool Manager instance.
+    pub fn manager(&self) -> &QuaintManager {
+        &*self.inner
+    }
+}
+
 impl TransactionCapable for PooledConnection {}
 
 #[async_trait]


### PR DESCRIPTION
This is a new method that lets you get a reference to the connection's manager from a PooledConnection.

In my use case, this is relevant as way to get to the ConnectionInfo for the connection.