### PR TITLE
chore: bump tiberius to 0.11.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ features = ["bundled"]
 optional = true
 
 [target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies.tiberius]
-version = "0.11.2"
+version = "0.11.6"
 optional = true
 features = ["sql-browser-tokio", "chrono", "bigdecimal"]
 


### PR DESCRIPTION
## Overview

Follow-up PR to https://github.com/prisma/tiberius/pull/271

Fixes a bigdecimal conversion overflow (and includes a bunch of other fixes).