### PR TITLE
Revert "Cargo.toml: connection-string 0.10.0 -> 0.14.0 (#437)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ bigdecimal = ["bigdecimal_"]
 fmt-sql = ["sqlformat"]
 
 [dependencies]
-connection-string = "0.1.14"
+connection-string = "0.1.10"
 percent-encoding = "2"
 tracing-core = "0.1"
 async-trait = "0.1"

--- a/src/ast/conditions.rs
+++ b/src/ast/conditions.rs
@@ -1,7 +1,7 @@
 use crate::ast::*;
 
 /// Tree structures and leaves for condition building.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub enum ConditionTree<'a> {
     /// `(left_expression AND right_expression)`
     And(Vec<Expression<'a>>),
@@ -12,6 +12,7 @@ pub enum ConditionTree<'a> {
     /// A single expression leaf
     Single(Box<Expression<'a>>),
     /// A leaf that does nothing to the condition, `1=1`
+    #[default]
     NoCondition,
     /// A leaf that cancels the condition, `1=0`
     NegativeCondition,
@@ -115,12 +116,6 @@ impl<'a> ConditionTree<'a> {
         } else {
             self
         }
-    }
-}
-
-impl<'a> Default for ConditionTree<'a> {
-    fn default() -> Self {
-        ConditionTree::NoCondition
     }
 }
 

--- a/src/ast/conditions.rs
+++ b/src/ast/conditions.rs
@@ -1,7 +1,7 @@
 use crate::ast::*;
 
 /// Tree structures and leaves for condition building.
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum ConditionTree<'a> {
     /// `(left_expression AND right_expression)`
     And(Vec<Expression<'a>>),
@@ -12,7 +12,6 @@ pub enum ConditionTree<'a> {
     /// A single expression leaf
     Single(Box<Expression<'a>>),
     /// A leaf that does nothing to the condition, `1=1`
-    #[default]
     NoCondition,
     /// A leaf that cancels the condition, `1=0`
     NegativeCondition,
@@ -116,6 +115,12 @@ impl<'a> ConditionTree<'a> {
         } else {
             self
         }
+    }
+}
+
+impl<'a> Default for ConditionTree<'a> {
+    fn default() -> Self {
+        ConditionTree::NoCondition
     }
 }
 


### PR DESCRIPTION
This _temporarily_  and _partially_ reverts commit 1f7025860ce06a3b86e64d2395f3fc50406df3e2. It currently prevents quaint from being updated on the QE.

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/25233379/230091607-2421a82d-e0c1-4fe2-a3b0-e65ceb9da331.png">

@miguelff Sorry for reverting it while you're away, I hope you'll understand. Feel free to cherry-pick/revert it back as soon as the issues are resolved.